### PR TITLE
@gib -> updating button style to current mocks and some color definitions tweaking

### DIFF
--- a/source/elements/buttons.html.haml
+++ b/source/elements/buttons.html.haml
@@ -10,7 +10,7 @@ title: Partner Engineering Style Guide
   .container
     .row
       .col-md-10
-        - ['btn-basic','btn-primary','btn-secondary','btn-highlight','btn-welcome','btn-disabled','btn-delete','btn-primary-gradient','btn-secondary-gradient','btn-highlight-gradient','btn-welcome-gradient'].each do |btn_class|
+        - ['btn-basic','btn-disabled','btn-primary','btn-secondary','btn-delete','btn-add','btn-secondary-add'].each do |btn_class|
           .unit{id: btn_class}
             %h3
               - if btn_class == 'btn-basic'
@@ -46,17 +46,17 @@ title: Partner Engineering Style Guide
             .row
               %div{ class: "col-md-4" }
                 %div
-                  %a{ href: "#", class: "btn btn-secondary-gradient #{btn_size} btn-full-width" }
+                  %a{ href: "#", class: "btn btn-secondary #{btn_size} btn-full-width" }
                     Add a fair booth
               %div{ class: "col-md-8" }
                 %pre
-                  &lt;a href=&quot;#&quot; class=&quot;btn btn-secondary-gradient #{btn_size} btn-full-width&quot;&gt;Add a show&lt;/a&gt;
+                  &lt;a href=&quot;#&quot; class=&quot;btn btn-secondary #{btn_size} btn-full-width&quot;&gt;Add a show&lt;/a&gt;
 
 
       .col-md-2
         .panel.panel-info.affix#section-nav
           %ul.nav.nav-pills.nav-stacked
-            - ['btn-basic','btn-primary','btn-secondary','btn-highlight','btn-disabled','btn-delete','btn-primary-gradient','btn-secondary-gradient','btn-highlight-gradient','btn-welcome-gradient','btn-full-width'].each do |btn_class|
+            - ['btn-basic','btn-disabled','btn-primary','btn-secondary','btn-delete','btn-add','btn-secondary-add', 'btn-full-width'].each do |btn_class|
               %li
                 %a{ href: "##{btn_class}"}
                   = btn_class

--- a/source/elements/forms.html.haml
+++ b/source/elements/forms.html.haml
@@ -68,4 +68,4 @@ title: Partner Engineering Style Guide
           .row
             .col-md-12
               .unit.bordered
-                %input.btn.btn-primary-gradient.btn-full-width{ type: "submit", name: 'Save changes' }
+                %input.btn.btn-primary.btn-full-width{ type: "submit", name: 'Save changes' }

--- a/source/elements/panels.html.haml
+++ b/source/elements/panels.html.haml
@@ -32,5 +32,5 @@ title: Partner Engineering Style Guide
         .panel.is-notice.text-center
           %p The featured show on your profile is out of date.
           %p
-            %a.btn.btn-highlight-gradient.btn-large{ href: "#" } Update Profile Feature
+            %a.btn.btn-large{ href: "#" } Update Profile Feature
           %p <em>You can always update this under <a href="#">'Shows & Fairs'</a></em>.

--- a/source/interface/form.html.haml
+++ b/source/interface/form.html.haml
@@ -80,4 +80,4 @@ title: Partner Engineering Style Guide
           .row
             .col-md-12
               .unit.bordered
-                %input.btn.btn-primary-gradient.btn-large.btn-full-width{ type: "submit", name: 'Save changes' }
+                %input.btn.btn-primary.btn-large.btn-full-width{ type: "submit", name: 'Save changes' }

--- a/vendor/assets/stylesheets/watt/_buttons.scss
+++ b/vendor/assets/stylesheets/watt/_buttons.scss
@@ -1,10 +1,12 @@
 // Basic (no style cf artsy.net hero)
+// Disabled (grey button; does not change on hover)
 // Primary (black with white text; hovers to purple with white text)
-// Secondary (grey with black text; hovers to purple with white text)
-// delete (thin grey border with black text; hovers to red border with red text; no gradient)
-// highlight (yellow background with black text; hovers to purple with white text)
-// welcome (purple background with white text; hovers to black with white text)
+// Secondary (follows basic button style)
+// Delete (follows basic style that hovers to red)
+// Add (prepends + to the button content)
+// Secondary-add (highlight background with no border, hovers to darker border)
 
+// basic
 
 input[type="submit"].btn,
 input[type="submit"].btn:visited,
@@ -22,13 +24,13 @@ input[type="submit"].btn:visited,
     weight: normal;
     family: $sans-serif;
   }
-  color: $buttoncolor;
+  color: $black;
   text-align: center;
   vertical-align: middle;
-  background-color: $buttonbackground;
+  background-color: transparent;
   border-width: 2px;
   border-style: solid;
-  border-color: $buttonbordercolor;
+  border-color: $base-border-color;
   text-transform:uppercase;
   font-weight:normal;
 
@@ -48,40 +50,13 @@ input[type="submit"].btn:visited,
   text-decoration: none;
 
   &:hover {
-    color: $white;
-    background-color: $purple;
-    border-color: $purple;
+    color: $purple;
     text-decoration: none;
   }
 }
 
-.selected-text-from-btn {
-  display: inline-block;
-  *display: inline;
-  /* IE7 inline-block hack */
-  *zoom: 1;
-
-  padding: 14px 20px 11px 20px;
-  font-size: 12px;
-  line-height: 12px;
-
-  margin-bottom: 0;
-  font: {
-    weight: normal;
-    family: $sans-serif;
-  }
-  color: $highlightcolor;
-  text-align: center;
-  vertical-align: middle;
-  background-color: $buttonbackground;
-  border-width: 2px;
-  border-style: solid;
-  border-color: transparent;
-  text-transform:uppercase;
-  font-weight:normal;
-}
-
 .btn:first-child { *margin-left: 0; }
+
 
 // disabled
 
@@ -98,46 +73,19 @@ a.btn.btn-disabled {
   }
 }
 
+
 // primary
 
 input[type="submit"].btn.btn-primary,
 a.btn.btn-primary,
 .btn-primary:visited {
   background-color: $black;
-  border-color: $buttonbordercolor;
+  border-color: $black;
   color: $white;
 
   &:hover {
     background-color: $purple;
     border-color: $purple;
-    color: $white;
-  }
-}
-
-// primary-gradient
-input[type="submit"].btn.btn-primary-gradient,
-a.btn.btn-primary-gradient,
-.btn-primary-gradient:visited {
-  @include linear-gradient(lighten($black, 35%), $black);
-  border: none;
-  color: $white;
-
-  &:hover {
-    @include linear-gradient($purple, $purple);
-    color: $white;
-  }
-}
-
-// secondary-gradient
-input[type="submit"].btn.btn-secondary-gradient,
-a.btn.btn-secondary-gradient,
-.btn-secondary-gradient:visited {
-  @include linear-gradient( lighten($black, 99%), lighten($black, 90%));
-  border: 1px solid lighten($black, 75%);
-  color: $black;
-  &:hover {
-    border: 1px solid $purple;
-    @include linear-gradient( $purple, $purple);
     color: $white;
   }
 }
@@ -148,81 +96,6 @@ a.btn.btn-secondary-gradient,
 input[type="submit"].btn.btn-secondary,
 a.btn.btn-secondary,
 .btn-secondary:visited {
-  background-color: lighten($black, 90%);
-  border-color: lighten($black, 90%);
-  color: $black;
-
-  &:hover {
-    background-color: $purple;
-    border-color: $purple;
-    color: $white;
-  }
-}
-
-// highlight
-
-input[type="submit"].btn.btn-highlight,
-a.btn.btn-highlight,
-.btn-highlight:visited {
-  background-color: $highlightcolor;
-  border-color: $highlightcolor;
-  color: $black;
-
-  &:hover {
-    background-color: $purple;
-    border-color: $purple;
-    color: $white;
-  }
-}
-
-// highlight-gradient
-input[type="submit"].btn.btn-highlight-gradient,
-a.btn.btn-highlight-gradient,
-.btn-highlight-gradient:visited {
-  @include linear-gradient( lighten($highlightcolor, 5%), $highlightcolor);
-  padding-top:12px;
-  border:1px solid #ddd;
-  padding-bottom:10px;
-  color: $black;
-  &:hover {
-    border: 1px solid $purple;
-    @include linear-gradient( $purple, $purple);
-    color: $white;
-  }
-}
-
-
-
-// welcome
-
-input[type="submit"].btn.btn-welcome,
-a.btn.btn-welcome,
-.btn-welcome:visited {
-  background-color: $purple;
-  border-color: $purple;
-  color: $white;
-
-  &:hover {
-    background-color: $black;
-    border-color: $black;
-    color: $white;
-  }
-}
-
-// welcome-gradient
-input[type="submit"].btn.btn-welcome-gradient,
-a.btn.btn-welcome-gradient,
-.btn-welcome-gradient:visited {
-  @include linear-gradient( lighten($purple, 15%), $purple);
-  padding-top:12px;
-  border:1px solid $purple;
-  padding-bottom:10px;
-  color: $white;
-  &:hover {
-    border: 1px solid $black;
-    @include linear-gradient( $black, $black);
-    color: $white;
-  }
 }
 
 
@@ -231,14 +104,39 @@ a.btn.btn-welcome-gradient,
 input[type="submit"].btn.btn-delete,
 a.btn.btn-delete,
 .btn-delete:visited {
-  background-color: $white;
-  border-color: lighten($black, 90%);
-  color: $black;
 
   &:hover {
     background-color: $white;
-    border-color: $deletecolor;
     color: $deletecolor;
+  }
+}
+
+
+// add
+
+input[type="submit"].btn.btn-add,
+a.btn.btn-add,
+.btn-add:visited {
+  &:before
+  {
+    content: "+ ";
+    position: relative;
+    top: -2px;
+  }
+}
+
+
+// secondary-add
+
+input[type="submit"].btn.btn-secondary-add,
+a.btn.btn-secondary-add,
+.btn-secondary-add:visited {
+  background-color: $highlightcolor;
+  border-color: $highlightcolor;
+  color: $black;
+
+  &:hover {
+    border-color: $dark-highlightcolor;
   }
 }
 

--- a/vendor/assets/stylesheets/watt/_contents.css.scss.erb
+++ b/vendor/assets/stylesheets/watt/_contents.css.scss.erb
@@ -110,7 +110,7 @@ main, section {
       }
       text-align: center;
       vertical-align: middle;
-      background-color: $buttonbackground;
+      background-color: $white;
       border-width: 4px;
       border-style: solid;
       border-color: transparent;

--- a/vendor/assets/stylesheets/watt/_variables.scss
+++ b/vendor/assets/stylesheets/watt/_variables.scss
@@ -1,9 +1,9 @@
 // Colors
 ////////////////////////////////////////////////////////////////////////////////
-$purple:#6a0bc1; // rgb(106, 11, 193)
-$white:#fff;
-$black:#000;
-$lightgrey:lighten($black, 75%);
+$purple             : #6600cc; // rgb(102, 0, 204);
+$white              : #fff;
+$black              : #000;
+$lightgrey          : lighten($black, 75%);
 $darkest-gray       : #333;
 $darker-gray        : #666;
 $dark-gray          : #999;
@@ -12,17 +12,14 @@ $light-gray         : #dbdbdb;
 $lighter-gray       : #e5e5e5;
 $lightest-gray      : #efefef;
 
-$buttonbackground   : $white;
-$buttonbordercolor  : $black;
-$buttoncolor        : $black;
+$alertcolor         : #fcf8e3; // rgb(252,248,227);
+$errorcolor         : #E51913; // rgb(229, 25, 19);
+$infocolor          : #7f7f7f; // rgb(127, 127, 127);
+$inverscolor        : #414141; // rgb(65,65,65);
+$successcolor       : #5bb75b; // rgb(91,183,91);
+$highlightcolor     : #f7edcf; // rgb(247, 237, 207);
+$dark-highlightcolor: #e0d8bd; // rgb(224, 216, 189); 
+$deletecolor        : #dd0000; // rgb(221, 0, 0);
 
-$alertcolor     : rgb(252,248,227);
-$errorcolor     : #E51913;
-$infocolor      : #7f7f7f;
-$inverscolor    : rgb(65,65,65);
-$successcolor   : rgb(91,183,91);
-$highlightcolor : #F7ECD0;
-$deletecolor    : rgb(218,79,73);
-
-$notice-color     : $highlightcolor;
-$base-border-color: $light-gray;
+$notice-color       : $highlightcolor;
+$base-border-color  : $medium-gray;


### PR DESCRIPTION
This should mostly complete https://github.com/artsy/watt/issues/43

Realized that this style was not included in the mock:
![screen shot 2014-05-22 at 12 28 41 pm](https://cloud.githubusercontent.com/assets/437156/3056870/5118b810-e1cf-11e3-953a-cd3a26821ab4.png)
![screen shot 2014-05-22 at 12 28 34 pm](https://cloud.githubusercontent.com/assets/437156/3056868/4e6f47a0-e1cf-11e3-83c5-8561a96bba69.png)

Also not sure if using :before filter and prepending a text is an acceptable solution for '+' button. It will not work on older browsers but will fail gracefully(just no + sign)
