### PR TITLE
@dylanfareed: fixes default form input text colors; version bump

### DIFF
--- a/lib/artsy/watt/version.rb
+++ b/lib/artsy/watt/version.rb
@@ -3,6 +3,6 @@ module Artsy
   # Watt is a shared asset library for Artsy Partner Engineering rails apps
   ###
   module Watt
-    VERSION = '0.0.1'
+    VERSION = '0.0.2'
   end
 end

--- a/vendor/assets/stylesheets/watt/_bootstrap_variables.css.scss
+++ b/vendor/assets/stylesheets/watt/_bootstrap_variables.css.scss
@@ -1,14 +1,15 @@
 // Full listing here: https://github.com/twbs/bootstrap/blob/master/less/variables.less
 
 // Global
+$brand-primary: #000;
 $font-family-sans-serif: $sans-serif;
 $font-family-serif: $serif;
 $font-family-base: $serif;
 $font-size-base: 16px;
-$brand-primary: #000;
-$input-border-focus: #999;
-$state-info-border: #DDD;
 $grid-float-breakpoint: 992px;
+$input-border-focus: #999;
+$input-color: $black;
+$state-info-border: #DDD;
 $text-color: $black;
 
 // Alerts


### PR DESCRIPTION
follow up to #67

Adds `input-color: $black` to fix default form input text colors.

Note that all the sass variables for bootstrap are listed here: https://github.com/twbs/bootstrap/blob/master/less/variables.less

Provides a version bump (that we should use going forward) so that we can start making sure that we are deploying with the correct version of watt.
