### PR TITLE
@gib -> updating nav-tabs style to latest comp

### DIFF
--- a/vendor/assets/stylesheets/watt/_bootstrap_overrides.css.scss
+++ b/vendor/assets/stylesheets/watt/_bootstrap_overrides.css.scss
@@ -21,16 +21,17 @@ body {
 .nav-tabs {
   margin-bottom: 20px;
   > li {
-    &:first-of-type {
-      margin-left: 2px;
+    &:last-of-type {
+      margin-right: 0;
     }
     > a {
-      background-color: $gray-lighter;
+      color: $gray-dark;
+      background-color: $white;
       border-color: $gray;
-      border-radius: 5px 5px 0 0;
       margin-right: 4px;
       &:hover {
-        background-color: $white;
+        background-color: $gray-lightest;
+        color: $black;
       }
     }
   }


### PR DESCRIPTION
Pretty minor changes here to get those tabs to look like this:
![screen shot 2014-05-28 at 3 55 47 pm](https://cloud.githubusercontent.com/assets/437156/3110061/e8de24c0-e6a0-11e3-8e49-721ed388fd17.png)

The first tab is rolled over there and the second one is active.
