### PR TITLE
@gib -> first pass at sidebar nav update

### DIFF
--- a/vendor/assets/stylesheets/watt/_split_medium.css.scss
+++ b/vendor/assets/stylesheets/watt/_split_medium.css.scss
@@ -9,7 +9,7 @@ body.interface_layout {
     margin-left: -180px;
     left: 180px;
     width: 180px;
-    background-color:#fff;
+    background-color: $white;
     position: fixed;
     height: 100%;
     overflow-y: auto;
@@ -24,24 +24,27 @@ body.interface_layout {
       margin: 0;
       padding: 0;
       ul {
-        padding: 70px 0 30px 0;
-        border-right: 1px solid #CACACA;
+        padding: 70px 10px 30px 5px;
+        border-right: 1px solid $gray;
         font-family: $sans-serif;
         text-transform: uppercase;
         li {
+          margin: 0;
           a {
-            color: black;
-            background-color: #fff;
+            padding: 15px;
+            color: $black;
+            background-color: $white;
+            border: 1px solid $white;
           }
           a:hover {
-            color: black;
-            background-color: #E6E6E6;
+            background-color: $gray-lightest;
+            border: 1px solid $gray-lightest;
           }
         }
         li.active {
           a {
-            color: black;
-            background-color: #E6E6E6;
+            border: 1px solid $black;
+            background-color: $white;
           }
         }
       }


### PR DESCRIPTION
This updates the 'spidernav' to the latest style on medium screens. Not sure what is it supposed to look like on super small screens, so not touching this part.

Also, seems like @spencerschimel using a smaller font on this nav but is pretty hard to judge based on the pdfs. Did not even see where is the font size for this is defined, so left it alone.
Looks like that at the moment:

![screen shot 2014-05-28 at 4 41 25 pm](https://cloud.githubusercontent.com/assets/437156/3110689/370758f4-e6a8-11e3-9946-d0c336ab9bb7.png)
