### PR TITLE
@gib Add lists controls and styles. Update style guide.

### DIFF
--- a/source/elements/lists.html.haml
+++ b/source/elements/lists.html.haml
@@ -11,6 +11,13 @@ title: Partner Engineering Style Guide
         %p In order to get vertically aligned icons, we need some extra mark up ¯\_(ツ)_/¯
         %pre
           :preserve
+            .list-controls
+              .list-controls-row
+                .list-control-filter
+                  %select.form-control
+              .list-controls-row
+                .list-control-counts Viewing 1 - 5 of 37 Artists
+                .list-control-sorting Sorted by: Most Recent / A-Z
             .list-group
               %a.list-group-item{ href: '#' }
                 %span.list-group-item-content
@@ -46,6 +53,51 @@ title: Partner Engineering Style Guide
               %span.list-group-item-info
                 Some extra information in an element classed <code>.list-group-item-info</code>
                 and child to <code>.list-group-item-content</code>.
+            %span.icon-chevron-right
+          %a.list-group-item{ href: '#' }
+            %span.list-group-item-content
+              %span.list-group-item-label Andy Warhol
+            %span.icon-chevron-right
+          %a.list-group-item{ href: '#' }
+            %span.list-group-item-content
+              %span.list-group-item-label Andy Warhol
+            %span.icon-chevron-right
+
+        %h4 Lists of links with controls
+        %p
+          Lists controls are usually on top of a list. They can be organized
+          into <code>.list-controls-row</code>s, and each control can adjust
+          the size, preferably by <code>make-md-column(n)</code> mixins, and
+          add additional styles.
+        .list-controls
+          .list-controls-row
+            .list-control-filter
+              %select.form-control
+                %option Filter by visibility
+                %option{ value: '1' } Visible
+                %option{ value: '0' } Invisible
+            .list-control-filter
+              %select.form-control
+                %option Filter by availability
+                %option{ value: '1' } Available
+                %option{ value: '0' } Unavailable
+          .list-controls-row
+            .list-control-counts
+              Viewing 1 - 5 of 37 Artists
+            .list-control-sorting
+              Sorted by: <a href="#" class="active">Most Recent</a> / <a href="#">A-Z</a>
+        .list-group
+          %a.list-group-item{ href: '#' }
+            %span.list-group-item-content
+              %span.list-group-item-label Andy Warhol
+            %span.icon-chevron-right
+          %a.list-group-item{ href: '#' }
+            %span.list-group-item-content
+              %span.list-group-item-label Andy Warhol
+            %span.icon-chevron-right
+          %a.list-group-item{ href: '#' }
+            %span.list-group-item-content
+              %span.list-group-item-label Andy Warhol
             %span.icon-chevron-right
           %a.list-group-item{ href: '#' }
             %span.list-group-item-content

--- a/vendor/assets/stylesheets/watt/_lists.css.scss
+++ b/vendor/assets/stylesheets/watt/_lists.css.scss
@@ -104,3 +104,32 @@
 .list-pager-next {
   text-align: right;
 }
+
+.list-controls {
+  @include clearfix();
+}
+
+.list-controls-row {
+  @include make-row();
+  margin-bottom: 15px;
+  &:last-child {
+    margin-bottom: 10px;
+  }
+}
+
+.list-control-filter {
+  @include make-md-column(4);
+}
+
+.list-control-counts,
+.list-control-sorting {
+  @include make-md-column(6);
+}
+
+.list-control-sorting {
+  text-align: right;
+  .active {
+    color: $purple;
+    text-decoration: underline;
+  }
+}


### PR DESCRIPTION
Re: [List widgets component and stylesheets](https://github.com/artsy/watt/issues/81)

Moved the lists controls upstream to watt. Updated the style guide.

Instead of [using bootstrap's columns like in Volt](https://github.com/artsy/volt/blob/master/app/views/partner_shows/index.html.haml#L29-L37), I created specific classes for the controls and used bootstrap mixins to generate the grid, to be more self-contained and compatible with existing elements. Clients can customize the styles by overriding the classes.

I will update Volt if this looks good to you! Thanks!

![list-control](https://cloud.githubusercontent.com/assets/796573/3163156/a4d5a3fc-eb3c-11e3-93ff-1d82e83c2e7c.png)
