### PR TITLE
@gib: provides no-border option for section headers; antialias headernav links

### DIFF
--- a/source/elements/section_headers.html.haml
+++ b/source/elements/section_headers.html.haml
@@ -33,3 +33,21 @@ title: Partner Engineering Style Guide
           Paragraph text - Lorem ipsum dolor sit amet, consectetur adipisicing elit,
           sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
           ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip.
+
+        .row.section-header.section-header-no-border
+          %h3 No border section
+          .section-actions
+            %a.btn.btn-primary.btn-small{ href: "#" } Do something
+            %a.btn.btn-primary.btn-small{ href: "#" } Do something else
+        %p
+          Paragraph text - Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+          sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+          ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip.
+
+        %pre
+          :preserve
+            .row.section-header.section-header-no-border
+              %h3 No border section
+              .section-actions
+                %a.btn.btn-primary.btn-small{ href: "#" } Do something
+                %a.btn.btn-primary.btn-small{ href: "#" } Do something else

--- a/vendor/assets/stylesheets/watt/_bootstrap_overrides.css.scss
+++ b/vendor/assets/stylesheets/watt/_bootstrap_overrides.css.scss
@@ -4,6 +4,7 @@ body {
   .nav-tabs a {
     text-transform: uppercase;
     font-family: $sans-serif;
+    -webkit-font-smoothing: antialiased;
   }
   .nav-tabs {
     border-color: $gray;

--- a/vendor/assets/stylesheets/watt/_lists.css.scss
+++ b/vendor/assets/stylesheets/watt/_lists.css.scss
@@ -25,7 +25,7 @@
 }
 
 .list-group-item {
-  @include transition(background-color 0.5s ease-in-out);
+  @include transition(background-color 0.25s ease-in-out);
   align-self: auto;
   border-bottom: 1px solid $gray;
   display: block;
@@ -34,7 +34,7 @@
     border-top: 1px solid $gray;
   }
   &[href]:hover {
-    background-color: #eee;
+    background-color: $gray-lightest;
     text-decoration: none;
   }
 }
@@ -67,7 +67,7 @@
 }
 .list-pager-prev, .list-pager-next {
   @include avant-garde();
-  @include transition(color 0.25s ease-in-out);
+  @include transition(color 0.125s ease-in-out);
   display: inline-block;
   width: 24%;
   &:hover {
@@ -80,7 +80,7 @@
   }
   .icon-chevron-left::before,
   .icon-chevron-right::before {
-    @include transition(color 0.25s ease-in-out);
+    @include transition(color 0.125s ease-in-out);
     color: $gray-light;
     // TODO: Fix this in the icon font
     margin-left: -2px;

--- a/vendor/assets/stylesheets/watt/_section_header.css.scss
+++ b/vendor/assets/stylesheets/watt/_section_header.css.scss
@@ -16,3 +16,7 @@
     @include margin(0 0 1px 0);
   }
 }
+.section-header.section-header-no-border {
+  border: none;
+  padding-bottom: 0;
+}


### PR DESCRIPTION
Lighten them nav links
![image](https://cloud.githubusercontent.com/assets/197336/3193944/134ba194-ecf8-11e3-82d1-4ddd58e5edf0.png)

.section-header-no-border
![image](https://cloud.githubusercontent.com/assets/197336/3193954/2afea0ca-ecf8-11e3-9c5b-dd11b1a4b92a.png)

also sneaks in a quicker hover transition for list-item groups

Closes #80
