### PR TITLE
@gib -> panels should not include margins by default. #minor

### DIFF
--- a/vendor/assets/stylesheets/watt/_panels.css.scss
+++ b/vendor/assets/stylesheets/watt/_panels.css.scss
@@ -3,8 +3,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 .panel {
   border: 1px solid $base-border-color;
-  margin: 15px;
-  padding: 15px;
+  margin: 0;
+  padding: $spacing-unit;
 
   &.is-notice {
     background-color: $notice-color;


### PR DESCRIPTION
As discussed yesterday - not add any margins here, add in the code directly if needed by adding a spacing class. I'm keeping padding here since it's part of the box which is panel.... the space outside of it is not part of the element itself.
