### PR TITLE
@gib - Fix 3 col artwork grid item artwork widths

### DIFF
--- a/vendor/assets/stylesheets/watt/_grid.css.scss
+++ b/vendor/assets/stylesheets/watt/_grid.css.scss
@@ -48,6 +48,10 @@
     text-align: center;
     vertical-align: middle;
   }
+  @include media($screen-md-min) {
+    height: 210px;
+    width: 210px;
+  }
 }
 .grid-item-artwork-low-res {
   @include avant-garde();


### PR DESCRIPTION
I had some responsive styles in the separate files before I added neat. Most of what I removed were causing other issues, but I removed this along with it. Put it in context with the grid item image.
