### PR TITLE
@gib: version bump; partner_selections style #minor

### DIFF
--- a/lib/artsy/watt/version.rb
+++ b/lib/artsy/watt/version.rb
@@ -3,6 +3,6 @@ module Artsy
   # Watt is a shared asset library for Artsy Partner Engineering rails apps
   ###
   module Watt
-    VERSION = '0.0.4'
+    VERSION = '0.0.5'
   end
 end

--- a/vendor/assets/stylesheets/watt/partner_selections.css.scss
+++ b/vendor/assets/stylesheets/watt/partner_selections.css.scss
@@ -1,0 +1,13 @@
+//
+// partner_selections
+// Provides minimal styling for Kinetic's partner_selections views.
+// Client apps mounting both Watt and Kinetic and requiring the partner_selections
+// interactions should add the following to their application.css files:
+//   *= require watt/partner_selections.css.scss
+//
+@import "watt/spaces";
+
+.partner_selections .icon-mark-large {
+  font-size: 16px * 4;
+  padding: $spacing-unit * 6 0;
+}


### PR DESCRIPTION
This is a bit of an antipattern. Adding a stylesheet specific to a set of kinetic views - https://github.com/artsy/kinetic/blob/master/app/controllers/kinetic/partner_selections_controller.rb

Kinetic however doesn't have javascript/css assets and we already have https://github.com/artsy/watt/blob/master/vendor/assets/javascripts/watt/partner_selections.js.coffee in Watt.

YOLO - :yellow_heart: 
