### PR TITLE
@gib - Hide disabled prev / next list-pager links

### DIFF
--- a/vendor/assets/stylesheets/watt/_lists.css.scss
+++ b/vendor/assets/stylesheets/watt/_lists.css.scss
@@ -66,6 +66,11 @@
   @include align-items(center);
   @include justify-content(space-between);
 }
+
+.list-pager-disabled {
+  visibility: hidden;
+}
+
 .list-pager-prev, .list-pager-next {
   @include garamond();
   @include transition(background-color 0.25s ease-in-out);


### PR DESCRIPTION
Pretty minor, just applies a `visibility: hidden` to @dylanfareed's `.list-pager-disabled` class.
