### PR TITLE
@gib Add list items with artworks.

### DIFF
--- a/source/elements/lists.html.haml
+++ b/source/elements/lists.html.haml
@@ -63,6 +63,32 @@ title: Partner Engineering Style Guide
               %span.list-group-item-label Andy Warhol
             %span.icon-chevron-right
 
+        %h4 Lists of links with artworks
+        %p
+          These will get an artwork image in each item with 1/3 width of the row. The width of the image will be set to fill the container, and the width/height will remain the same ratio.
+        .list-group
+          %a.list-group-item{ href: '#' }
+            %span.list-group-item-image
+              %img{ src: "/images/hurricaneLXXXIV.png" }
+            %span.list-group-item-content
+              %span.list-group-item-label Andy Warhol
+            %span.icon-chevron-right
+          %a.list-group-item{ href: '#' }
+            %span.list-group-item-image
+              %img{ src: "/images/cliff.png" }
+            %span.list-group-item-content
+              %span.list-group-item-label Andy Warhol
+              %span.list-group-item-info
+                Some extra information in an element classed <code>.list-group-item-info</code>
+                and child to <code>.list-group-item-content</code>.
+            %span.icon-chevron-right
+          %a.list-group-item{ href: '#' }
+            %span.list-group-item-image
+              %img{ src: "/images/trees_in_snow.png" }
+            %span.list-group-item-content
+              %span.list-group-item-label Andy Warhol
+            %span.icon-chevron-right
+
         %h4 Lists of links with controls
         %p
           Lists controls are usually on top of a list. They can be organized

--- a/vendor/assets/stylesheets/watt/_lists.css.scss
+++ b/vendor/assets/stylesheets/watt/_lists.css.scss
@@ -39,6 +39,18 @@
   }
 }
 
+.list-group-item-image {
+  display: inline-block;
+  width: 33.33%;
+  min-height: 100px;
+  padding-right: 20px;
+  vertical-align: middle;
+  > img { width: 100%; }
+  + .list-group-item-content {
+    width: calc(66.66% - 34px);
+  }
+}
+
 .list-group-item-content {
   display: inline-block;
   vertical-align: middle;


### PR DESCRIPTION
Re: [watt#44](https://github.com/artsy/watt/issues/44)

Moved the list view with artworks from Volt to Watt. Will update Volt after this! Thanks!
- Currently, the image width/height remains. We can add a new class for square images.
- The inline-block white space is annoying, and decided to shrink the width of `.list-group-item-content` to eliminate that (see comments inline.) Thanks!

![partner engineering style guide](https://cloud.githubusercontent.com/assets/796573/3303733/8d9086f6-f642-11e3-9ebf-27beddbe15da.png)

![partner engineering style guide2](https://cloud.githubusercontent.com/assets/796573/3303780/1bc8aec6-f643-11e3-930a-6bf162ae852b.png)
