### PR TITLE
@gib -> breadcrumb styles updates

### DIFF
--- a/source/elements/breadcrumbs.html.haml
+++ b/source/elements/breadcrumbs.html.haml
@@ -5,6 +5,10 @@ title: Partner Engineering Style Guide
   .container
     .row
       .col-md-12
+        .bordered.page-title
+          %h2 Breadcrumbs
+    .row
+      .col-md-12
         .section-breadcrumb.clearfix
           .section-breadcrumb-link
             %a{ href: "#" } Home
@@ -12,10 +16,14 @@ title: Partner Engineering Style Guide
           .section-breadcrumb-link
             %a{ href: "#" } Section
           .section-breadcrumb-separator.icon-chevron-right-large
+          .section-breadcrumb-link
+            %a{ href: "#" } And Another Section
+          .section-breadcrumb-separator.icon-chevron-right-large
+          .section-breadcrumb-link
+            %a{ href: "#" } Even More Sections
+          .section-breadcrumb-separator.icon-chevron-right-large
           .section-breadcrumb-title Active Section
 
-        .page-title
-          %h2 Breadcrumbs
         %pre
           :preserve
             .row

--- a/vendor/assets/stylesheets/watt/_breadcrumbs.css.scss
+++ b/vendor/assets/stylesheets/watt/_breadcrumbs.css.scss
@@ -1,15 +1,21 @@
+// Height of breadcrumb line itself not accounting for padding/margin
+$line-height: 18px;
+
 .section-breadcrumb {
   border-bottom: 1px solid $base-border-color;
-  margin: -1$spacing-unit 0 3*$spacing-unit 0;
+  @extend .double-padding-bottom;
+  @extend .double-margin-bottom;
   .section-breadcrumb-link,
   .section-breadcrumb-title,
   .section-breadcrumb-separator {
     float: left;
-    line-height: 4.5*$spacing-unit;
+    line-height: $line-height;
   }
 
   .section-breadcrumb-separator {
+    color: $gray;
     font-size: 18px;
+    padding: 0 0 0 $spacing-unit;
   }
 
   .section-breadcrumb-link,
@@ -18,9 +24,11 @@
   }
 
   .section-breadcrumb-link {
-    padding: $spacing-unit 0 1.2*$spacing-unit $spacing-unit;
+    padding: 0 0 0 $spacing-unit;
     a {
       color: $gray-dark;
+      display: block;
+      line-height: $line-height;
       text-decoration: none;
       &:hover {
         color: $purple;
@@ -29,12 +37,19 @@
     }
   }
 
-  .section-breadcrumb-separator {
-    color: $gray;
-    padding: $spacing-unit 0 0 $spacing-unit;
-  }
   .section-breadcrumb-title {
-    padding: $spacing-unit;
-    padding-bottom: 1.2*$spacing-unit;
+    padding: 0 $spacing-unit;
   }
-} 
+}
+
+// Adjustments for very smaill screens
+@media (max-width: $screen-sm-min) {
+  .section-breadcrumb {
+    padding-bottom: $spacing-unit;
+    .section-breadcrumb-link,
+    .section-breadcrumb-title,
+    .section-breadcrumb-separator {
+      padding-bottom: $spacing-unit;
+    }
+  }
+}

--- a/vendor/assets/stylesheets/watt/_spaces.css.scss
+++ b/vendor/assets/stylesheets/watt/_spaces.css.scss
@@ -35,7 +35,7 @@ $spacing-unit: 10px;
 .half-padding-top {
   padding-top: $spacing-unit/2;
 }
-.two-third-padding {
+.two-third-padding-top {
   padding-top: $spacing-unit*2/3;
 }
 .single-padding-top {


### PR DESCRIPTION
I updated the html on the breadcrumb page to follow current volt structure, so I think it will look the same in volt once we do the update.

Here is the moving image...
![breadcrumbs](https://cloud.githubusercontent.com/assets/437156/3320503/0cdcca26-f72b-11e3-91a7-2cd4a2ea3fb2.gif)

I think we might need to group together the link and the carrot if we want them to wrap as a groop on screen resizing but it does not bother me too much as is... Let me know if you think it's annoying enough that those jump separately.
