### PR TITLE
@gib Modal refactor

### DIFF
--- a/vendor/assets/stylesheets/watt/_modals.css.scss.erb
+++ b/vendor/assets/stylesheets/watt/_modals.css.scss.erb
@@ -2,19 +2,19 @@
   .unit { 
     @extend .single-padding;
   }
+  .fancybox-inner { padding-top: 40px; }
 }
 
 .fancybox-inner {
   h2 {
     @extend .single-padding-bottom;
     @extend .single-margin-bottom;
-    font-size:22px;
-    line-height: 22px;
+    font-size: 26px;
+    line-height: 26px;
     font-family:$serif;
     text-align:left;
     color:black;
     font-weight:normal;
-    border-bottom: 1px solid #CACACA;
   }
   .row {
     margin: 0;
@@ -22,20 +22,39 @@
       text-decoration: underline;
     }
   }
-  .close-modal {
-    float: right;
-    background-color: #fff;
-    width: 30px;
-    height: 30px;
-    float: right;
+  .modal {
+    height: 100%;
+    overflow: auto;
+  }
+  .modal-close {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 26px;
+    height: 26px;
     padding: 0;
     margin: 0;
+    z-index: 3;
     a {
       @extend .with-icon;
       @extend .icon-close;
       color: black;
-      font-size: 30px;
+      font-size: 26px;
       text-decoration: none;
     }
+  }
+  .modal-header {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 40px;
+    background-color: white;
+    z-index: 2;
+  }
+  .modal-content {
+    overflow: hidden;
+  }
+  .modal-footer {
   }
 }


### PR DESCRIPTION
Re: [#105](https://github.com/artsy/watt/issues/105)
- Refactored the modal window and defined the structure of the structure that client would use:

``` haml
.modal
  .modal-close
  .modal-header            
    %h2 Modal Header
  .modal-content
    %p Modal content here 
```
- Replaced the close image with the icon font from Joule!
- Fixed the modal header and the close button.
- The scrollbar position is a bit tricky, and will come back later. Thanks!

![modal](https://cloud.githubusercontent.com/assets/796573/3346757/bf142fda-f8cb-11e3-9131-3156d381edde.png)
![modal2](https://cloud.githubusercontent.com/assets/796573/3346758/c2c15e28-f8cb-11e3-8c90-f7efda77be4b.gif)
