### PR TITLE
@starsirius #minor Fix nav-tabs margin bottom.

### DIFF
--- a/vendor/assets/stylesheets/watt/_bootstrap_overrides.css.scss
+++ b/vendor/assets/stylesheets/watt/_bootstrap_overrides.css.scss
@@ -14,7 +14,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .nav-tabs {
-  @extend .double-margin-bottom;
+  margin-bottom: $spacing-unit*2;
   border-color: $gray;
   font-size:12px;
   &.active {


### PR DESCRIPTION
Just realized that I used sass `@extend` the wrong way. When a class is extending another class, the compiled css gets lifted up all the way to where the extended class is (in this case, `.double-margin-bottom`), and, here, the `.nav-tabs` loses its ability of overriding default bootstrap's `.nav-tabs` margin. I have to be careful about using `@extend` from now on.

![tab-nav-margin2](https://cloud.githubusercontent.com/assets/796573/3435538/a7d0e8c2-0096-11e4-9dda-5766639be320.png)
![tab-nav-margin1](https://cloud.githubusercontent.com/assets/796573/3435539/a7d1d48a-0096-11e4-80b5-6882c1ebb2cf.png)
