### PR TITLE
@gib: adds force-style toggles to watt

### DIFF
--- a/source/elements/forms.html.haml
+++ b/source/elements/forms.html.haml
@@ -33,6 +33,36 @@ title: Partner Engineering Style Guide
             .col-md-12
               .unit.bordered.single-padding-top
                 .col-md-3
+                  %h5 Some options
+                .col-md-9
+                  .form-group
+                    %label.col-sm-2.control-label
+                      Enable downloads
+                    .col-sm-10
+                      %a.toggle{ data: { state: 'on' }}
+                        .toggle-dot
+                  .form-group
+                    %label.col-sm-2.control-label
+                      Enable zoom
+                    .col-sm-10
+                      %a.toggle{ data: { state: 'off' }}
+                        .toggle-dot
+                  .form-group
+                    %label.col-sm-2.control-label
+                      Published?
+                    .col-sm-10
+                      %a.toggle{ data: { state: 'yes' }}
+                        .toggle-dot
+                  .form-group
+                    %label.col-sm-2.control-label
+                      For sale?
+                    .col-sm-10
+                      %a.toggle{ data: { state: 'no' }}
+                        .toggle-dot
+          .row
+            .col-md-12
+              .unit.bordered.single-padding-top
+                .col-md-3
                   %h5 Price
                 .col-md-9
                   .form-group

--- a/source/javascripts/toggles.js.coffee
+++ b/source/javascripts/toggles.js.coffee
@@ -1,0 +1,14 @@
+$ ->
+  $('.toggle').click (e) ->
+    e.preventDefault()
+    $this     = $(this)
+    $toggle   = if $this.is '.toggle-label' then $this.prev() else $this.closest 'a.toggle'
+    $toggle.attr 'data-state':
+      if $toggle.is "[data-state='on']"
+        'off'
+      else if $toggle.is "[data-state='off']"
+        'on'
+      else if $toggle.is "[data-state='yes']"
+        'no'
+      else if $toggle.is "[data-state='no']"
+        'yes'

--- a/vendor/assets/stylesheets/watt/_toggles.scss
+++ b/vendor/assets/stylesheets/watt/_toggles.scss
@@ -1,0 +1,66 @@
+.toggle-label {
+  display: inline-block;
+  margin-left: 10px;
+  &:hover {
+    color: $purple;
+    cursor: pointer;
+  }
+}
+
+.toggle {
+  @include avant-garde();
+  background-color: white;
+  border: 2px solid $gray-lighter;
+  border-radius: 15px;
+  color: $gray;
+  cursor: pointer;
+  display: inline-block;
+  line-height: 17px;
+  text-decoration: none;
+  transition: 'color, border-color' 0.2s;
+  width: 58px;
+  &:focus, &:hover {
+    @extend .toggle-label;
+    color: $purple;
+    text-decoration: none;
+    margin: 0;
+    padding: 0;
+  }
+  &::after {
+    content: attr(data-state);
+    display: inline;
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: -1px;
+    margin-left: 0;
+    position: relative;
+    transition: margin-left 0.2s;
+    top: -2px;
+    width: 20px;
+  }
+  .toggle-dot {
+    display: inline;
+    font-size: 30px;
+    left: 2px;
+    position: relative;
+    top: 4px;
+    transition: left 0.2s;
+    &::after {
+      content: "\25CF";
+    }
+  }
+  &[data-state='on'],
+  &[data-state='yes'] {
+    background-color: $purple;
+    border-color: $purple;
+    .toggle-dot {
+      color: white;
+      left: 33px;
+    }
+    &::after {
+      color: white;
+      content: attr(data-state);
+      margin-left: -15px;
+    }
+  }
+}

--- a/vendor/assets/stylesheets/watt/base.css.scss
+++ b/vendor/assets/stylesheets/watt/base.css.scss
@@ -33,6 +33,7 @@
 @import "watt/typekit";
 @import "watt/section_header";
 @import "watt/spinners";
+@import "watt/toggles";
 
 // Watt responsives
 //// Extra small devices (tiny screens in landscape, 420 and up)


### PR DESCRIPTION
Ports the toggles in the force style-guide to watt. I actually can't find the toggles on artsy.net any longer since the user settings updates...

Closes #116 

We'll use these in CMS/Admin contexts I bet tho. Supports Yes/No and On/Off states.

The haml markup is pretty straightforward:

```
%a.toggle{ data: { state: 'on' }}
  .toggle-dot
```

![toggle-party](https://cloud.githubusercontent.com/assets/197336/3560119/e25729a8-095a-11e4-8c4e-6655a8e24f0e.gif)
