### PR TITLE
@gib: small adjustments to navbar height & nav search positioning

### DIFF
--- a/source/layouts/interface_layout.haml
+++ b/source/layouts/interface_layout.haml
@@ -26,7 +26,7 @@
         })();
       //]]>
   %body#rotation-app{ class: "interface_layout #{page_classes}" }
-    %header.navbar.navbar-default.navbar-fixed-top{role: 'navigation'}
+    %header.navbar.navbar-default.navbar-fixed-top.navbar-inverse{role: 'navigation'}
       .navbar-header
         %button.navbar-toggle{data: {target: '.navbar-collapse', toggle: 'collapse'}, type: 'button'}
           %span.sr-only
@@ -39,7 +39,7 @@
         %form#navbar-search.navbar-form.navbar-left{ role: "Search" }
           .form-group
             %input{ type: "text", class: "form-control", placeholder: "Search" }
-        %ul.nav.navbar-nav.hidden-md.hidden-lg
+        %ul.nav.navbar-nav.hidden-lg.hidden-md.hidden-sm
           - ['dashboard','artists','inventory','shows','orders'].each do |nav_item|
             %li{class: ( 'active' if nav_item.include? 'artists' ) }
               %a{ href: "/interface/items"}

--- a/vendor/assets/stylesheets/watt/_bootstrap_overrides.css.scss
+++ b/vendor/assets/stylesheets/watt/_bootstrap_overrides.css.scss
@@ -80,6 +80,7 @@ header.navbar.navbar-inverse .dropdown-menu {
   background-color: $black;
   border-color: $black;
   -webkit-box-shadow: none;
+  -moz-box-shadow: none;
   box-shadow: none;
   a {
     color: $white;
@@ -134,14 +135,34 @@ header.navbar.navbar-inverse {
 header.navbar li a {
   font-size: 12px;
 }
-@media (min-width: $screen-md-min) {
+
+#navbar-search, .navbar-form, .navbar-collapse {
+  border: none;
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
+}
+
+@media (min-width: $screen-sm-min) {
   header.navbar li a {
     font-size: 13px;
   }
   #navbar-search {
-    width: 600px;
-    input {
-      width: 600px;
+    width: 400px;
+    padding: 0;
+    .form-group {
     }
+  }
+}
+
+@media (min-width: $screen-md-min) {
+  #navbar-search {
+    width: 600px;
+  }
+}
+
+@media (min-width: $screen-lg-min) {
+  #navbar-search {
+    margin-left: 95px;
   }
 }

--- a/vendor/assets/stylesheets/watt/_bootstrap_variables.css.scss
+++ b/vendor/assets/stylesheets/watt/_bootstrap_variables.css.scss
@@ -16,7 +16,7 @@ $alert-info-bg: $yellow-light;
 $alert-info-border: $yellow-light;
 
 // Navbar
-$navbar-height: 55px;
+$navbar-height: 50px;
 $navbar-default-bg: #E6E6E6;
 $navbar-default-border: #C9C9C9;
 $border-radius-base: 0px;

--- a/vendor/assets/stylesheets/watt/_split_small.css.scss
+++ b/vendor/assets/stylesheets/watt/_split_small.css.scss
@@ -19,7 +19,7 @@ body.interface_layout {
     // .navigation
     .navigation {
       position: absolute;
-      top: 56px;
+      top: 51px;
       bottom: 0;
       width: 160px;
       list-style: none;


### PR DESCRIPTION
- Gets rid of weirdo bootstrap inverse pulldown borders and shadows
- Kicks navbar height down to 50px
- Tightens up search input alignment (should match top/bottom of logomark)
- Lines search up with the sidebar on lg viewports
- Cooks cookies for the bake sale

![search-tweaks](https://cloud.githubusercontent.com/assets/197336/3562914/c9b66f86-0a12-11e4-8753-dff128ac01bf.gif)
