### PR TITLE
gib: adds updated bootstrap tab variables - active borders same color as inactive tabs

### DIFF
--- a/vendor/assets/stylesheets/watt/_bootstrap_variables.css.scss
+++ b/vendor/assets/stylesheets/watt/_bootstrap_variables.css.scss
@@ -50,8 +50,10 @@ $input-border-focus: $purple;
 $input-color-placeholder: $gray-light;
 
 // Tabs
-$nav-tabs-border-color: #DDD;
-$nav-tabs-link-hover-border-color: #DDD;
-$nav-tabs-active-link-hover-color: #000;
-$nav-tabs-active-link-hover-bg: #FFF;
-$nav-tabs-justified-link-border-color: #DDD;
+$nav-tabs-border-color: $gray;
+$nav-tabs-link-hover-border-color: $gray;
+$nav-tabs-active-link-hover-bg: $white;
+$nav-tabs-active-link-hover-color: $black;
+$nav-tabs-active-link-hover-border-color: $gray;
+$nav-tabs-justified-link-border-color: $gray;
+$nav-tabs-justified-active-link-border-color: $gray;


### PR DESCRIPTION
This was a weirdly subtle thing because of how were overriding some but not all of bootstraps tab-related variables.

The active tabs were a slightly different color than the inactive tabs (#ddd rather than #ccc).
![image](https://cloud.githubusercontent.com/assets/197336/3603877/244e841e-0d1b-11e4-848f-d48aa189237e.png)

This is how they should look afterward.
![image](https://cloud.githubusercontent.com/assets/197336/3603903/596b4524-0d1b-11e4-912c-7feb2a3b4a96.png)
