### PR TITLE
@gib #minor Cursor style of disabled buttons.

### DIFF
--- a/vendor/assets/stylesheets/watt/_buttons.scss
+++ b/vendor/assets/stylesheets/watt/_buttons.scss
@@ -78,6 +78,7 @@ a.btn.btn-disabled {
   background-color: lighten($black, 90%);
   border-color: lighten($black, 90%);
   color: $white;
+  cursor: default;
 
   &:hover, &:visited {
     background-color: $white;


### PR DESCRIPTION
# minor

Would like to display default cursor style for disabled link. Thanks!

![untitled](https://cloud.githubusercontent.com/assets/796573/3647624/b560f3a4-1100-11e4-8501-77f35f807577.png)
