### PR TITLE
@oxaudo Front-end tweaks for autocomplete widget.

### DIFF
--- a/vendor/assets/stylesheets/watt/_autocomplete.css.scss
+++ b/vendor/assets/stylesheets/watt/_autocomplete.css.scss
@@ -2,8 +2,8 @@ ul.ui-autocomplete {
   list-style: none;
   padding: 0;
   border: solid 1px #ccc;
+  border-top: none;
   cursor: default;
-  max-width:300px;
   -webkit-box-shadow: 0 1px 5px rgba(0,0,0,0.1);
   -moz-box-shadow: 0 1px 5px rgba(0,0,0,0.1);
   box-shadow: 0 1px 5px rgba(0,0,0,0.1);
@@ -11,15 +11,16 @@ ul.ui-autocomplete {
     background-color: #FFF;
     border-top: solid 1px #ccc;
     margin: 0;
-    padding: 0;
     a {
       font-size: 16px;
       color: #000;
       display: block;
-      padding: 6px;
+      padding: 6px 13px;
+      &:hover { text-decoration: none; }
     }
-    a.ui-state-hover, a.ui-state-active {
-      background-color: #FFFCB2;
+    a.ui-state-hover, a.ui-state-focus {
+      background-color: $purple;
+      color: $white;
     }
   }
   li:hover {


### PR DESCRIPTION
Updated the autocomplete widget to match with our styles a bit. The interaction part (javascript) will be included in Volt in for following PR. Thanks.
- Removed the `max-width` so that the searched items can be aligned with the input.
- Used the purple color for navigation.

![screen shot 2014-07-24 at 5 38 14 pm](https://cloud.githubusercontent.com/assets/796573/3695163/e4f9e810-137a-11e4-8226-7bc3181cd75f.png)
