### PR TITLE
@starsirius - Updates to the empty list group message pattern

### DIFF
--- a/source/elements/lists.html.haml
+++ b/source/elements/lists.html.haml
@@ -178,14 +178,21 @@ title: Partner Engineering Style Guide
           :preserve
             .list-group 
               <b># Note the emptiness!</b>
-            .list-group-empty-message
-              No list items here!
-              %p
-                .btn.btn-add.btn-full-width Add a List Item
+            .list-group-empty-message[-bordered]
+              This show contains no documents.
 
+        %p For a single <code>list-group</code> on the page, use <code>list-group-empty-message</code>.
         %br
         .list-group
         .list-group-empty-message
-          No list items here!
-          %p
-            .btn.btn-add.btn-full-width Add a List Item
+          This show contains no documents.
+
+        %br
+        %p For one of many <code>list-group</code> sections use <code>list-group-emtpy-message-bordered</code>.
+        .clearfix.section-header
+          %h3 Press and Documents
+          .section-actions
+            %a.btn.btn-primary.btn-small.btn-add{ href: "" } Add a Document
+        .list-group
+        .list-group-empty-message-bordered
+          This show contains no documents.

--- a/vendor/assets/stylesheets/watt/_lists.css.scss
+++ b/vendor/assets/stylesheets/watt/_lists.css.scss
@@ -205,13 +205,24 @@ a.list-pager-page-link {
   }
 }
 
-.list-group-empty-message {
+// Empty list messages
+.list-group:empty,
+.list-group-empty-message,
+.list-group-empty-message-bordered {
   display: none;
 }
-.list-group:empty + .list-group-empty-message {
-  @include avant-garde();
+.list-group:empty + .list-group-empty-message,
+.list-group:empty + .list-group-empty-message-bordered {
+  @include garamond();
   display: block;
+  font-style: italic;
+}
+.list-group:empty + .list-group-empty-message {
+  font-size: 18px;
   padding: 100px 0;
   text-align: center;
-  width: 100%;
+}
+.list-group-empty-message-bordered {
+  border-bottom: 1px solid $base-border-color;
+  padding: 15px 10px;
 }


### PR DESCRIPTION
This updates the styling of the message and adds another style `.list-group-empty-message-bordered` for use in overview pages that have sections of short `.list-group`s.

![screen shot 2014-07-28 at 5 45 19 pm](https://cloud.githubusercontent.com/assets/94830/3727688/ada0001a-16a0-11e4-9de0-d53171f713f5.png)
