### PR TITLE
@gib: updates panel styles

### DIFF
--- a/source/elements/panels.html.haml
+++ b/source/elements/panels.html.haml
@@ -10,16 +10,27 @@ title: Partner Engineering Style Guide
 
         %p A panel puts some content in a box.
         .panel
-          %h5 Heading
+          %h4 Heading
           %p
             Paragraph text - Lorem ipsum dolor sit amet, consectetur adipisicing elit,
             sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
             ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip.
-
+          %p
+            Paragraph text - Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore
+            %a{ href: "#" } et dolore magna aliqua.
+            Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip.
+        %p
+          Sometimes its nice to constrain the width of the content. It's classed with <code>.is-constrained</code>.
+        .panel.is-constrained
+          %p
+            Paragraph text - Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore
+            %a{ href: "#" } et dolore magna aliqua.
+          %p
+            Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip.
         %p
           This panel serves as a notice. It's classed with <code>.is-notice</code>.
         .panel.is-notice
-          %h3 Complete these 5 Steps to upload a complete show.
+          %h4 Complete these 5 Steps to upload a complete show.
           %ol
             %li Upload the press release and other documents
             %li Add a description for this show

--- a/vendor/assets/stylesheets/watt/_panels.css.scss
+++ b/vendor/assets/stylesheets/watt/_panels.css.scss
@@ -2,12 +2,39 @@
 // Panels
 ////////////////////////////////////////////////////////////////////////////////
 .panel {
-  border: 1px solid $base-border-color;
-  margin: 0;
-  padding: $spacing-unit;
-
+  background-color: $gray-lightest;
+  border-left: 2px solid $purple;
+  box-shadow: none;
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  padding: 2*$spacing-unit;
+  h4, p, ol, ul, li {
+    color: $gray-darkest;
+  }
+  h4, p, ol, ul {
+    margin-bottom: $spacing-unit;
+    a {
+      text-decoration: underline;
+      &:hover {
+        color: $purple;
+      }
+      &.btn {
+        text-decoration: none;
+      }
+    }
+  }
+  p, ol, ul {
+    &:last-child {
+      margin: 0;
+    }
+  }
   &.is-notice {
     background-color: $notice-color;
     border: none;
+  }
+  &.is-constrained {
+    h3, h4, p {
+      max-width: 440px;
+    }
   }
 }


### PR DESCRIPTION
We've got this convention (that I think is a good one) of having instructions (next step or how this feature works on Artsy.net) on screen. These info panels should not be the bright yellow IMO.

Putting a pin in this for now, but wanted to update these prior to circling up with design for feedback.

![image](https://cloud.githubusercontent.com/assets/197336/3766920/176aaa7a-18c9-11e4-8656-a6390807aa28.png)

![image](https://cloud.githubusercontent.com/assets/197336/3766924/2162977c-18c9-11e4-9a2a-64d39ed5946a.png)

![image](https://cloud.githubusercontent.com/assets/197336/3766931/2e33e924-18c9-11e4-89a2-4600698dca64.png)

Before:
![image](https://cloud.githubusercontent.com/assets/197336/3766971/7de79d58-18c9-11e4-9f3e-98c6acebcc19.png)

Before:
![image](https://cloud.githubusercontent.com/assets/197336/3766977/8912d2a6-18c9-11e4-8212-9903d9267a97.png)

After:
![image](https://cloud.githubusercontent.com/assets/197336/3766997/a803134c-18c9-11e4-8ff8-e47f124f1f98.png)
