### PR TITLE
@dylanfareed Port tooltips from Force.

### DIFF
--- a/source/elements/index.html.haml
+++ b/source/elements/index.html.haml
@@ -46,3 +46,7 @@ title: Partner Engineering Style Guide
             %span.list-group-item-content
               %span.list-group-item-label Breadcrumbs
             %span.icon-chevron-right
+          %a.list-group-item{ href: "/elements/utilities" }
+            %span.list-group-item-content
+              %span.list-group-item-label Utilities
+            %span.icon-chevron-right

--- a/source/elements/utilities.html.haml
+++ b/source/elements/utilities.html.haml
@@ -1,0 +1,25 @@
+---
+title: Partner Engineering Style Guide
+---
+#content-wrap
+  .container
+    .row
+      .col-md-10
+        .page-title.bordered
+          %h2 Utilities
+
+        .unit.double-padding-top
+          %h4.single-padding-bottom Help Tooltip
+
+          %p
+            Help tooltips can be displayed inline with content. The default<span class="help-tooltip" data-message='Works in which the idea, planning, and production process are more important than the result. The term gained currency in the 1960s as a result of Sol LeWitt’s 1967 article "Paragraphs on Conceptual Art" in Artforum.'></span>style is anchored to the top-left.
+          %p
+            They can also be anchored to the top-right<span class="help-tooltip" data-message='Works in which the idea, planning, and production process are more important than the result. The term gained currency in the 1960s as a result of Sol LeWitt’s 1967 article "Paragraphs on Conceptual Art" in Artforum.' data-anchor="top-right"></span>The bottom-left<span class="help-tooltip" data-message='Works in which the idea, planning, and production process are more important than the result. The term gained currency in the 1960s as a result of Sol LeWitt’s 1967 article "Paragraphs on Conceptual Art" in Artforum.' data-anchor="bottom-left"></span>Or the bottom-right<span class="help-tooltip" data-message='Works in which the idea, planning, and production process are more important than the result. The term gained currency in the 1960s as a result of Sol LeWitt’s 1967 article "Paragraphs on Conceptual Art" in Artforum.' data-anchor="bottom-right"></span>.
+
+          .unit.double-padding-top
+            %pre
+              :preserve
+                %span.help-tooltip{ data: { message: 'Works in which the idea...' } }
+                %span.help-tooltip{ data: { message: 'Works in which the idea...', anchor: 'top-right' } }
+                %span.help-tooltip{ data: { message: 'Works in which the idea...', anchor: 'bottom-left' } }
+                %span.help-tooltip{ data: { message: 'Works in which the idea...', anchor: 'bottom-right' } }

--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -72,6 +72,10 @@ title: Partner Engineering Style Guide
             %a{ href: "/elements/breadcrumbs", class: '' }
               %strong
                 Breadcrumbs
+          %li
+            %a{ href: "/elements/utilities", class: '' }
+              %strong
+                Utilities
   .container
     .unit.bordered.single-padding
       Built on #{Time.now.to_formatted_s(:long)}

--- a/vendor/assets/stylesheets/watt/_tooltips.css.scss
+++ b/vendor/assets/stylesheets/watt/_tooltips.css.scss
@@ -1,0 +1,93 @@
+.help-tooltip {
+  @include garamond();
+  display: inline-block;
+  position: relative;
+  cursor: help;
+  margin: 0 0.5em;
+  width: 14px;
+  height: 14px;
+  // Visually center with Garamond
+  margin-bottom: -2px;
+  &:before, &:after {
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+  &:before {
+    content: '?';
+    z-index: 2;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    // Vertically centers in FF by adding 1
+    // Chrome remains centered as well
+    line-height: 15px;
+    text-align: center;
+    vertical-align: middle;
+    font-family: sans-serif;
+    font-size: 12px;
+    font-weight: bold;
+    color: white;
+    background-color: $gray-darker;
+  }
+  &:after {
+    visibility: hidden;
+    content: attr(data-message);
+    text-align: left;
+    z-index: 1;
+    margin: -10px 0 0 -10px;
+    width: 350px;
+    color: white;
+    background-color: black;
+    padding: 30px;
+    opacity: 0;
+    line-height: 1.3;
+  }
+  &:hover {
+    &:before {
+      z-index: 4;
+    }
+    &:after {
+      opacity: 1;
+      z-index: 3;
+      @include transition(opacity 0.125s);
+      visibility: visible;
+    }
+  }
+  // Variants
+  //
+  // Todo: Add sizes and more anchor
+  // &[data-anchor='top-left']
+  // top-left is default
+  &[data-anchor='top-right'] {
+    &:before, &:after {
+      top: 0;
+      left: inherit;
+      right: 0;
+    }
+    &:after {
+      margin: -10px -10px 0 0;
+    }
+  }
+  &[data-anchor='bottom-left'] {
+    &:before, &:after {
+      top: inherit;
+      bottom: 0;
+    }
+    &:after {
+      margin: 0 0 -10px -10px;
+    }
+  }
+  &[data-anchor='bottom-right'] {
+    &:before, &:after {
+      top: inherit;
+      left: inherit;
+      right: 0;
+      bottom: 0;
+    }
+    &:after {
+      margin: 0 -10px -10px 0;
+    }
+  }
+}

--- a/vendor/assets/stylesheets/watt/base.css.scss
+++ b/vendor/assets/stylesheets/watt/base.css.scss
@@ -37,6 +37,7 @@
 @import "watt/summary_detail";
 @import "watt/toggles";
 @import "watt/checkboxes";
+@import "watt/tooltips";
 
 // Watt responsives
 //// Extra small devices (tiny screens in landscape, 420 and up)


### PR DESCRIPTION
The tooltips utility in [Force](https://artsy.net/style-guide) might be useful in Volt, so I port it over and will try this in the artwork editing form.

![screen shot 2014-08-06 at 1 02 24 pm](https://cloud.githubusercontent.com/assets/796573/3830598/bf03a87e-1d8b-11e4-949a-d36975f41e4f.png)

![tooltips](https://cloud.githubusercontent.com/assets/796573/3830599/c1003fb6-1d8b-11e4-9a1f-3cad70fdbcdf.gif)
