### PR TITLE
@dylan -> modifying panel width constrains

### DIFF
--- a/vendor/assets/stylesheets/watt/_panels.css.scss
+++ b/vendor/assets/stylesheets/watt/_panels.css.scss
@@ -33,8 +33,11 @@
     border: none;
   }
   &.is-constrained {
-    h3, h4, p, div {
+    h3, h4, p {
       max-width: 440px;
     }
+  }
+  .width-constrained {
+    max-width: 660px;
   }
 }


### PR DESCRIPTION
This reverts my latest change since it added more problems and was not the right width anyways. Created a separate class width-constrained to be used to limit width for not too long of a line when we need it. The width is arbitrary here, that what I figured looks not too long:)
