### PR TITLE
@gib - Adds the shortlist icon to watt's css

### DIFF
--- a/vendor/assets/stylesheets/watt/_icons.css.scss.erb
+++ b/vendor/assets/stylesheets/watt/_icons.css.scss.erb
@@ -76,3 +76,6 @@
 .icon-shows:before {
   content: "\e60d";
 }
+.icon-shortlist:before {
+  content: "\e60e";
+}


### PR DESCRIPTION
See https://github.com/artsy/joule/pull/32
![screen shot 2014-10-23 at 5 06 03 pm](https://cloud.githubusercontent.com/assets/94830/4762944/5791e848-5b09-11e4-9eb5-e5805c19b5e3.png)

The fonts have been updated in S3. Existing fonts retained their character mappings, so we should get the new one for free once these updates go in Volt.
