### PR TITLE
@gib #minor Hide overflowed tab elements.

### DIFF
--- a/vendor/assets/stylesheets/watt/_tabs.css.scss
+++ b/vendor/assets/stylesheets/watt/_tabs.css.scss
@@ -1,4 +1,7 @@
 $s: 768px;
+.tabs-wrap {
+  overflow: hidden;
+}
 .tabs {
   height: 50px;
   margin: 0 0 2 * $spacing-unit 0;


### PR DESCRIPTION
Hide the overflowed `tabs-overflow-indicator` so that it won't go beyond the page container and help iphone lock the horizontal scrolling. See the screencasts below.

If this makes sense to you, I will go ahead and add this class to all the tabs in Volt. Thanks!
##### Before

![tabs-overflow-2](https://cloud.githubusercontent.com/assets/796573/5192810/42861a2c-74c8-11e4-9d2c-9b610c05cf93.gif)
##### After

![tabs-overflow](https://cloud.githubusercontent.com/assets/796573/5192811/42895052-74c8-11e4-99d2-bc35a4b66297.gif)
