### PR TITLE
@dylanfareed: adds a search component css/svg

### DIFF
--- a/app/views/layouts/watt/minimal.haml
+++ b/app/views/layouts/watt/minimal.haml
@@ -18,8 +18,6 @@
     - if lookup_context.template_exists? 'head', 'layouts', true
       = render partial: 'layouts/head'
 
-    %script{ type: 'text/javascript', src: '//fast.fonts.net/jsapi/f7f47a40-b25b-44ee-9f9c-cfdfc8bb2741.js' }
-
     = csrf_meta_tag
 
   %body#watt-app{ class: "#{controller.controller_name}_#{controller.action_name}" }

--- a/app/views/shared/watt/svgs/_search.haml
+++ b/app/views/shared/watt/svgs/_search.haml
@@ -1,0 +1,7 @@
+%svg{ width: '20px', height: '22px', viewBox: '0 0 20 22', version: '1.1', xmlns: 'http://www.w3.org/2000/svg', 'xmlns:xlink' => 'http://www.w3.org/1999/xlink' }
+  %title Search Icon
+
+  %g{ id: 'search-icon', stroke: 'none', 'stroke-width' => '1', fill: 'none', 'fill-rule' => 'evenodd', 'sketch:type' => 'MSPage'}
+    %g{ id: 'search-icon-group', 'sketch:type' => 'MSLayerGroup', fill: '#000000'}
+      %path{ id: 'search-icon-path-1', d: 'M16.299,14.535 C15.784,15.171 15.19,15.736 14.537,16.229 L18.223,19.975 L19.965,18.261 L16.299,14.535 L16.299,14.535 Z'}
+      %path{ id: 'search-icon-path-2', d: 'M8.204,16.334 C3.699,16.334 0.034,12.669 0.034,8.164 C0.034,3.659 3.699,-0.006 8.204,-0.006 C12.709,-0.006 16.374,3.659 16.374,8.164 C16.374,12.669 12.71,16.334 8.204,16.334 L8.204,16.334 Z M8.204,2.138 C4.881,2.138 2.178,4.841 2.178,8.164 C2.178,11.487 4.881,14.19 8.204,14.19 C11.527,14.19 14.23,11.487 14.23,8.164 C14.231,4.841 11.527,2.138 8.204,2.138 L8.204,2.138 Z'}

--- a/vendor/assets/stylesheets/watt/_search_component.css.scss
+++ b/vendor/assets/stylesheets/watt/_search_component.css.scss
@@ -1,0 +1,28 @@
+.search-component {
+  position: relative;
+  .search-submit {
+    border-left: 1px solid $gray-lightest;
+    border-bottom: none;
+    border-right: none;
+    border-top: none;
+    background-color: $white;
+    height: 24px;
+    width: 30px;
+    position: absolute;
+    right: 6px;
+    top: 6px;
+    svg {
+      path {
+        @include transition(color 0.25s ease-in-out);
+        fill: $gray-dark;
+      }
+    }
+    &:hover {
+      svg {
+        path {
+          fill: $black;
+        }
+      }
+    }
+  }
+}

--- a/vendor/assets/stylesheets/watt/base.css.scss
+++ b/vendor/assets/stylesheets/watt/base.css.scss
@@ -34,6 +34,7 @@
 @import "watt/split";
 @import "watt/typekit";
 @import "watt/section_header";
+@import "watt/search_component";
 @import "watt/spinners";
 @import "watt/summary_detail";
 @import "watt/toggles";


### PR DESCRIPTION
This adds an svg partial and css for a search component.

It looks like this
![image](https://cloud.githubusercontent.com/assets/197336/5385120/af60683e-808d-11e4-8221-57e548ee3a99.png)

I'm adding an issue to provide an example in the style-guide as I want to figure out how to reference the partial svg from within the middleman project (maybe also thinking we should move the style guide to its own app and double down on it).

In the meantime, I've marked the partners search box in vibrations thusly.

``` ruby
.row.single-padding-top
  .col-md-12
    = simple_form_for(:search, url: search_partners_url, html: {class: 'search-component', role: 'Search', id: 'partner-search-form'}, method: :get) do |f|
      = f.input :term, required: false, as: :string, label: false, input_html: { value: (params[:search] && params[:search][:term]) ? params[:search][:term] : '', type: 'text', placeholder: 'Search' }, wrapper_html: { class: 'search-field' }
      %button.search-submit
        = render partial: '/shared/watt/svgs/search'
```
