### PR TITLE
@gib: upstream volt callback triggers and volt animations

### DIFF
--- a/vendor/assets/javascripts/watt/callback_triggers.js.coffee
+++ b/vendor/assets/javascripts/watt/callback_triggers.js.coffee
@@ -1,0 +1,2 @@
+$ ->
+  $('[data-remote="true"][data-callback="true"]').click()

--- a/vendor/assets/javascripts/watt/remote_animations.js.coffee
+++ b/vendor/assets/javascripts/watt/remote_animations.js.coffee
@@ -1,0 +1,15 @@
+$ ->
+  # Show the loading spinner on a button when it is used to make an AJAX call.
+  $('body').on('ajax:send', '[data-remote="true"]', (event, xhr) ->
+    tagName = event.target.tagName.toLowerCase()
+    # The button is either a submit button in a form or a link with data-remote=true
+    $btn = if tagName is 'form' then $(event.target).find('[type="submit"]') else $(event.target)
+    $btn.addClass 'is-loading'
+  )
+
+  # Restore the button state after the AJAX call is complete.
+  $('body').on('ajax:complete', '[data-remote="true"]', (event, xhr, status) ->
+    tagName = event.target.tagName.toLowerCase()
+    $btn = if tagName is 'form' then $(event.target).find('[type="submit"]') else $(event.target)
+    $btn.removeClass 'is-loading'
+  )


### PR DESCRIPTION
Volt as a lovely set of triggers for handling remote interactions. We should make these available to other apps. https://github.com/artsy/volt/commit/44c2f2605b517c1922ba75301383289edc48a618#diff-3a80a786551f3c25cf2dce3209a5aad8R1

I've split them into two files.

In Vibrations will use like this:

Application.js
![image](https://cloud.githubusercontent.com/assets/197336/5649286/b1a37628-9662-11e4-86a6-97c82d5cdd9e.png)

View template
![image](https://cloud.githubusercontent.com/assets/197336/5649296/c203adda-9662-11e4-8171-87cbd24513bb.png)

Controller 
![image](https://cloud.githubusercontent.com/assets/197336/5649348/11c78724-9663-11e4-8a61-b29ca7588f78.png)

Results:
![remote-animations](https://cloud.githubusercontent.com/assets/197336/5649359/1f9c5b40-9663-11e4-9802-ed1aee9efe99.gif)
