### PR TITLE
Fix bootstrap collapse

### DIFF
--- a/vendor/assets/stylesheets/watt/_bootstrap_base.scss
+++ b/vendor/assets/stylesheets/watt/_bootstrap_base.scss
@@ -27,23 +27,3 @@
 
 // Utility classes
 @import "bootstrap/utilities";
-/*
-.collapse {
-  display: none;
-  visibility: hidden;
-  &.in {
-    display: block;
-    visibility: visible;
-  }
-}
-tr.collapse.in    { display: table-row; }
-tbody.collapse.in { display: table-row-group; }
-.collapsing {
-  position: relative;
-  height: 0;
-  overflow: hidden;
-  @include transition-property('height, visibility');
-  @include transition-duration(0.25s);
-  @include transition-timing-function(ease-in-out);
-}
-*/


### PR DESCRIPTION
Some fallout from my bootstrap slashing last week. I noticed that the artwork edit sections would no longer expand / collapse.
