### PR TITLE
@starsirius  -> more properly center help ? icon and make sure the ? is not italic

### DIFF
--- a/vendor/assets/stylesheets/watt/_tooltips.scss
+++ b/vendor/assets/stylesheets/watt/_tooltips.scss
@@ -22,10 +22,11 @@
     border-radius: 50%;
     // Vertically centers in FF by adding 1
     // Chrome remains centered as well
-    line-height: 15px;
+    line-height: 16px;
     text-align: center;
     vertical-align: middle;
     font-family: sans-serif;
+    font-style: normal;
     font-size: 12px;
     font-weight: bold;
     color: white;


### PR DESCRIPTION
This pr should make sure the help question mark looks like that:
![screen shot 2015-04-01 at 11 52 52 am](https://cloud.githubusercontent.com/assets/437156/6944919/44cc652a-d864-11e4-92c0-ff2f02caa099.png)

vs like that:
![screen shot 2015-04-01 at 11 53 07 am](https://cloud.githubusercontent.com/assets/437156/6944925/4d1dbe04-d864-11e4-9e6c-37b9893826e4.png)
