### PR TITLE
@gib Bring back bootstrap responsive-utilities classes.

### DIFF
--- a/vendor/assets/stylesheets/watt/_bootstrap_base.scss
+++ b/vendor/assets/stylesheets/watt/_bootstrap_base.scss
@@ -27,3 +27,4 @@
 
 // Utility classes
 @import "bootstrap/utilities";
+@import "bootstrap/responsive-utilities";


### PR DESCRIPTION
At some point we got rid of the responsive utility classes, so the `.hidden-xs` class used in various places of Volt is not actually working. The utility classes are pretty lightweight. I think it's worth bringing them back, so we can hide some stuff on mobile very quickly.

https://github.com/twbs/bootstrap/blob/49519e981614fb8e0c4fabcbb0a632db292c2b3c/less/responsive-utilities.less
