### PR TITLE
@starsirius - Make the tabular content flex displays more specific

### DIFF
--- a/vendor/assets/stylesheets/watt/_lists.scss
+++ b/vendor/assets/stylesheets/watt/_lists.scss
@@ -65,10 +65,6 @@
 .list-group-item-content {
   @include garamond();
   @include flex(1 1px);
-  @include media(min-width $screen-sm-min) {
-    @include display(flex);
-    @include align-items(center);
-  }
 }
 
 .list-group-item-content-sub {
@@ -140,6 +136,10 @@
   }
   .list-group-item-content {
     display: block;
+    @include media(min-width $screen-sm-min) {
+      @include display(flex);
+      @include align-items(center);
+    }
   }
   .list-group-item-content-sub {
     margin-bottom: $spacing-unit;


### PR DESCRIPTION
When I added the the tabular list items (https://github.com/artsy/watt/pull/216), I under specified a media query that added a `display: flex` to the list item content causing this issue:
![screen shot 2015-04-28 at 11 13 09 pm](https://cloud.githubusercontent.com/assets/94830/7385097/6ec5d73c-edfc-11e4-921a-f1e3ea109a06.png)

I made sure this only applies to lists with the `.list-group-tabular` class to restore lists to:
![screen shot 2015-04-28 at 11 13 15 pm](https://cloud.githubusercontent.com/assets/94830/7385110/8fed418e-edfc-11e4-8811-92f4326e1394.png)

Will update Volt after this goes in.
