### PR TITLE
@dylanfareed -> removing a style for the artwork-artist-name

### DIFF
--- a/style-guide/source/interface/item.html.haml
+++ b/style-guide/source/interface/item.html.haml
@@ -40,10 +40,12 @@ title: Partner Engineering Style Guide
                     .artwork-grid-item-image
                       %img{ src: ['/images/trees_in_snow.png', '/images/cliff_sq.png', '/images/cliff.png', '/images/hurricaneLXXXIV_sq.png'].sample }
                       .artwork-grid-item-low-res Low-Res
-                    %h3.artwork-grid-item-artist-name Josef Hoflehner
-                    %h3.artwork-grid-item-title
+                    %h3.artwork-grid-item-artists
+                      .arwork-artists
+                        .artist-name Josef Hoflehner
+                        .artist-name Tatiana Trouvé
+                    %h3.artwork-grid-item-title.artwork-title
                       %a{ href: "#" } Trees in Snow
-
                     .artwork-grid-item-display-data
                       %span.data-label Visibility
                       %span.visiblity= ['Visible', 'Private'].sample

--- a/vendor/assets/stylesheets/watt/_contents.scss
+++ b/vendor/assets/stylesheets/watt/_contents.scss
@@ -3,6 +3,20 @@ main.full-width {
 }
 
 main, section {
+  // artwork in the content
+  .artwork-title {
+    font-style: italic;
+  }
+
+  .artwork-artists {
+    .artist-name {
+      @include avant-garde();
+      font-size: 14px;
+      line-height: 20px;
+      text-transform: uppercase;
+    }
+  }
+
   .page-title.bordered {
     @extend .double-margin-bottom;
     border-bottom: 1px solid $gray;

--- a/vendor/assets/stylesheets/watt/_grid.scss
+++ b/vendor/assets/stylesheets/watt/_grid.scss
@@ -88,19 +88,19 @@
       width: 100%;
     }
   }
-  .artwork-grid-item-artist-name {
+  .artwork-grid-item-title {
+    @include ellipsis();
+    display: block;
+    font-size: 15px;
+    margin: 0 0 $spacing-unit 0;
+  }
+  .artwork-grid-item-artists {
     @include avant-garde();
     @include ellipsis();
     display: block;
     font-size: 14px;
+    line-height: 20px;
     margin: $spacing-unit 0 0.5*$spacing-unit 0;
-  }
-  .artwork-grid-item-title {
-    @include ellipsis();
-    display: block;
-    font-style: italic;
-    font-size: 15px;
-    margin: 0 0 $spacing-unit 0;
   }
   .artwork-grid-item-display-data {
     font-size: 14px;


### PR DESCRIPTION
Replacing it with style s for `artwork-artists` and `artwork-artist` under it.

I think it'll be more generic approach going forward. We'll probably need to figure out how to deal in the grid item with multiple artists displays. For now it'll just cut them off....

cc @starsirius @gib 
