### PR TITLE
@gib Tabular list tweaks.

### DIFF
--- a/vendor/assets/stylesheets/watt/_lists.scss
+++ b/vendor/assets/stylesheets/watt/_lists.scss
@@ -69,11 +69,9 @@
 
 .list-group-item-content-sub {
   padding-right: 2*$spacing-unit;
+  @include word-wrap(break-word);
   @include media(min-width $screen-sm-min) {
     @include flex(2);
-    &:last-of-type {
-      @include flex(1);
-    }
   }
 }
 
@@ -136,10 +134,6 @@
   }
   .list-group-item-content {
     display: block;
-    @include media(min-width $screen-sm-min) {
-      @include display(flex);
-      @include align-items(center);
-    }
   }
   .list-group-item-content-sub {
     margin-bottom: $spacing-unit;
@@ -164,9 +158,10 @@
     }
   }
   /* wide enough for n columns */
-  @include media(min-width $screen-sm-min) {
+  @include media(min-width $screen-md-min) {
     .list-group-item-content {
       @include display(flex);
+      @include align-items(center);
     }
     .list-group-item-content-sub {
       margin-bottom: 0;


### PR DESCRIPTION
Closes https://github.com/artsy/watt/issues/221

A few things to note
- Break the word (usually long filenames as in the screencast) when there is no enough space.
- Switch to mobile view (no flexbox) when the viewport is smaller than `$screen-md-min` (used to be `$screen-sm-min`), given that tabular view tends to have more columns.
- Make all the `.list-group-item-content-sub` same size by default. It seems like in the new design we use the tabular list in various ways. We can customize the size for specific columns individually.
- Keep the `align-items(center)` by default. We can customize the alignment individually, for example, in the offers list we align them with [baseline](https://github.com/artsy/volt/blob/7990894309a780ef4a5c87051b0a775d681c2fea/app/assets/stylesheets/conversations.scss#L25).

![tabular-list](https://cloud.githubusercontent.com/assets/796573/7661026/40012e14-fb1d-11e4-91ff-5f0e44ffba8e.gif)
