### PR TITLE
@anyone Do not wrap text in tooltips.

### DIFF
--- a/vendor/assets/stylesheets/watt/_tooltips.scss
+++ b/vendor/assets/stylesheets/watt/_tooltips.scss
@@ -1,5 +1,6 @@
 .help-tooltip {
   @include garamond();
+  @include word-wrap(normal);
   display: inline-block;
   position: relative;
   cursor: help;


### PR DESCRIPTION
In the tabular list we wrap long words (usually emails) in the content, and the `word-wrap` property of the tooltips will inherit the value from it. This reset the value to normal. Will update Volt as well.

![screen shot 2015-05-28 at 3 53 07 pm](https://cloud.githubusercontent.com/assets/796573/7869638/0a9a8da8-0552-11e5-9da6-88de7de74460.png)
