### PR TITLE
@anyone Specify icon font file format.

### DIFF
--- a/vendor/assets/stylesheets/watt/_icons.scss.erb
+++ b/vendor/assets/stylesheets/watt/_icons.scss.erb
@@ -7,7 +7,7 @@
 // static.artsy.net or directly via S3 - gravity-production.s3.amazonaws.com
 //
 // This env var is set in semaphore for Watt to '/assets/watt/artsy-pe-icons'
-@include font-face(artsy-pe-icons, <%= ENV['ICON_FONT_PATH'] || 'watt/artsy-pe-icons' %>, normal, $asset-pipeline: true);
+@include font-face(artsy-pe-icons, <%= ENV['ICON_FONT_PATH'] || 'watt/artsy-pe-icons' %>, normal, $asset-pipeline: true, $file-formats: eot woff svg ttf);
 
 [class^="icon-"], [class*=" icon-"], .with-icon {
   font-family: 'artsy-pe-icons';


### PR DESCRIPTION
We don't output the `woff2` format for icon fonts in [Joule](https://github.com/artsy/joule/tree/master/output/fonts).

<img width="1440" alt="screen shot 2015-07-08 at 4 29 00 pm" src="https://cloud.githubusercontent.com/assets/796573/8581411/8603606c-258e-11e5-9b33-ccf0976f0ebd.png">
