### PR TITLE
@dylanfareed  -> removing inquiry icon sinse it's not used and magically appears in volt

### DIFF
--- a/vendor/assets/stylesheets/watt/_icons.scss.erb
+++ b/vendor/assets/stylesheets/watt/_icons.scss.erb
@@ -25,9 +25,6 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-.icon-inquiry:before {
-  content: "\e599";
-}
 .icon-search:before {
   content: "\e600";
 }


### PR DESCRIPTION
I believed it's not used in any projects.
Maybe make sense to clean it in joule as well.

should help https://github.com/artsy/volt/issues/1471
