### PR TITLE
@starsirius  -> adding one more styl to the buttons that looks like link

### DIFF
--- a/style-guide/source/elements/buttons.html.haml
+++ b/style-guide/source/elements/buttons.html.haml
@@ -10,7 +10,7 @@ title: Partner Engineering Style Guide
   .container
     .row
       .col-md-10
-        - ['btn-basic','btn-disabled','btn-primary','btn-secondary','btn-delete','btn-add','btn-secondary-add'].each do |btn_class|
+        - ['btn-basic','btn-disabled','btn-primary','btn-secondary','btn-delete','btn-add','btn-secondary-add', 'btn-link'].each do |btn_class|
           .unit{id: btn_class}
             %h3
               - if btn_class == 'btn-basic'
@@ -56,7 +56,7 @@ title: Partner Engineering Style Guide
       .col-md-2
         .panel.panel-info.affix#section-nav
           %ul.nav.nav-pills.nav-stacked
-            - ['btn-basic','btn-disabled','btn-primary','btn-secondary','btn-delete','btn-add','btn-secondary-add', 'btn-full-width'].each do |btn_class|
+            - ['btn-basic','btn-disabled','btn-primary','btn-secondary','btn-delete', 'btn-link', 'btn-add','btn-secondary-add', 'btn-full-width'].each do |btn_class|
               %li
                 %a{ href: "##{btn_class}"}
                   = btn_class

--- a/vendor/assets/stylesheets/watt/_buttons.scss
+++ b/vendor/assets/stylesheets/watt/_buttons.scss
@@ -149,6 +149,33 @@ a.btn.btn-secondary,
 }
 
 
+// link
+
+input[type="submit"].btn.btn-link,
+button.btn.btn-link,
+a.btn.btn-link,
+.btn-link:visited {
+  background-color: transparent;
+  border-color: transparent;
+  text-decoration: underline;
+  &:hover {
+    background-color: transparent;
+    color: $black;
+    text-decoration: none;
+  }
+
+  &[data-state='loading'],
+  &.is-loading {
+    color: $black;
+    &:after {
+      content: '';
+      display: block;
+      @include spinner(25px, 6px, $purple);
+    }
+  }
+}
+
+
 // delete
 
 input[type="submit"].btn.btn-delete,


### PR DESCRIPTION
As this https://github.com/artsy/currents-web/issues/42 requires `Skip` and `Edit` links in the header to look like links but be sized and aligned like buttons. Possibly even have outline on roll-over (not sure about that).

Figured it's easier to just add one more style to current buttons and this way we get all the fonts/sizing matching for free.
