### PR TITLE
@starsirius  -> #minor - follow up on loading state of link button

### DIFF
--- a/vendor/assets/stylesheets/watt/_buttons.scss
+++ b/vendor/assets/stylesheets/watt/_buttons.scss
@@ -166,7 +166,9 @@ a.btn.btn-link,
 
   &[data-state='loading'],
   &.is-loading {
-    color: $black;
+    border-color: $gray-lighter;
+    color: $gray-lighter;
+    text-decoration: none;
     &:after {
       content: '';
       display: block;


### PR DESCRIPTION
re: https://github.com/artsy/watt/pull/243/files#r49495073

That is the look now. Can always update further...
<img width="375" alt="screen shot 2016-01-13 at 12 20 41 pm" src="https://cloud.githubusercontent.com/assets/437156/12301878/58c306b0-b9f0-11e5-928e-f6dfc3bcb0b8.png">
