### PR TITLE
Allow shorty modals to reset their height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 #### Features
 
+* [#259](https://github.com/artsy/watt/pull/259): Allow shorty modals to reset their height - [@gnilekaw](https://github.com/gnilekaw).
 * [#256](https://github.com/artsy/watt/pull/256): Rename pe- icons to watt-icon icons - [@oxaudo](https://github.com/oxaudo).
 * [#255](https://github.com/artsy/watt/pull/255): Updates gray colors for better contrasts - [@gnilekaw](https://github.com/gnilekaw).
 * [#254](https://github.com/artsy/watt/pull/254): Fixes purple borders on visited buttons - [@gnilekaw](https://github.com/gnilekaw).

--- a/vendor/assets/stylesheets/watt/_remodal_artsy.scss
+++ b/vendor/assets/stylesheets/watt/_remodal_artsy.scss
@@ -63,8 +63,11 @@ $fixed-footer-height: 70px;
       top: $modal-padding;
       min-height: $fixed-header-height;
     }
+    .modal-content {
+      margin-bottom: $modal-padding * 2;
+    }
     .modal-footer {
-      bottom: $modal-padding;
+      bottom: $modal-padding / 2;
       min-height: $fixed-footer-height;
       //overflow: hidden;
       // align the content of footer to the bottom
@@ -94,4 +97,11 @@ $fixed-footer-height: 70px;
       }
     }
   }
+}
+
+// Reset the height for shorty modals
+.remodal.artsy-modal.reset-height {
+  height: auto;
+  .modal-inner { padding-bottom: 0 }
+  .modal-content { margin-bottom: 0 }
 }


### PR DESCRIPTION
This PR adds a class `reset-height` to `artsy-modal` that allows short modals to crop at an acceptable height.

See https://github.com/artsy/volt/issues/2366