### PR TITLE
move delete icons to have style similar to link icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 #### Features
 
+* [#263](https://github.com/artsy/watt/pull/263): Move delete/remove icons to have style similar to link icons - [@oxaudo](https://github.com/oxaudo).
 * [#260](https://github.com/artsy/watt/pull/260): Adding support for `input-group` and `input-group-addon` - [@ashkan18](https://github.com/ashkan18).
 * [#259](https://github.com/artsy/watt/pull/259): Allow shorty modals to reset their height - [@gnilekaw](https://github.com/gnilekaw).
 * [#256](https://github.com/artsy/watt/pull/256): Rename pe- icons to watt-icon icons - [@oxaudo](https://github.com/oxaudo).

--- a/vendor/assets/stylesheets/watt/_grid.scss
+++ b/vendor/assets/stylesheets/watt/_grid.scss
@@ -123,13 +123,13 @@
     text-decoration: none;
   }
   .grid-item-artwork-view,
-  .grid-item-artwork-quick-edit {
+  .grid-item-artwork-quick-edit,
+  .artwork-grid-action-remove,
+  .artwork-grid-action-delete {
     line-height: 24px;
   }
   .artwork-grid-action-edit,
-  .artwork-grid-action-save,
-  .artwork-grid-action-remove,
-  .artwork-grid-action-delete {
+  .artwork-grid-action-save {
     float: right;
     margin: 0 0 0 0.5*$spacing-unit;
     padding: 0;


### PR DESCRIPTION
This should help address first point in this story: https://github.com/artsy/collector-experience/issues/115

It's a bit strange that we keep this artwork grid/list view here in watt. I don't believe it's used anywhere but volt. But if it is - I'm potentially breaking actions icons style.

I still think it's worth updating it here vs define yet another style for this in Volt. In general I think Volt can use some clean up with those list/grid views. Since list view is used very little right now after we switched to react view for list on artworks view. Is is still used in search and unpublish artworks view (that is only available to fair partners).