### PR TITLE
specify word wrap for artist name

### DIFF
--- a/vendor/assets/stylesheets/watt/_lists.scss
+++ b/vendor/assets/stylesheets/watt/_lists.scss
@@ -119,6 +119,7 @@
   @include avant-garde();
   font-size: 15px;
   line-height: 15px;
+  word-break: normal;
 }
 
 .list-group-item-info {


### PR DESCRIPTION
We want to add name/year to artist name display on artists page in volt. This will make the name wrap in most cases - want to make sure that we don't break the words when not absolutely necessary.

Pretty minor change - so no changelog here:)