### PR TITLE
Adds Unica font

### DIFF
--- a/vendor/assets/stylesheets/watt/_fonts.scss
+++ b/vendor/assets/stylesheets/watt/_fonts.scss
@@ -1,7 +1,11 @@
-// Fonts from fonts.com
+// Garamond and Avant Garde fonts from fonts.com
 //
 // Requires that you provide the following fonts.com script tag.
 // <script type="text/javascript" src="http://fast.fonts.net/jsapi/f7f47a40-b25b-44ee-9f9c-cfdfc8bb2741.js"></script>
+
+// Unica77 from Lineto.com loaded from https://webfonts.artsy.net/unica-webfonts.css
+//
+// Reguires above css file to be loaded in the page header
 
 // Font Variables
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Follow up to https://github.com/artsy/volt/pull/3183

Adds Unica77 to watt to be used in artwork list page header.

usage: `font-family: $sans-regular;`

<img width="1265" alt="screen shot 2018-09-11 at 11 54 05 am" src="https://user-images.githubusercontent.com/687513/45371818-761d2980-b5b9-11e8-8e31-091a1ea8fe07.png">

cc: @starsirius 
 