### PR TITLE
Remove typekit

### DIFF
--- a/vendor/assets/stylesheets/watt/_typekit.css
+++ b/vendor/assets/stylesheets/watt/_typekit.css
@@ -1,3 +1,0 @@
-.wf-loading {
-  visibility: hidden;
-}

--- a/vendor/assets/stylesheets/watt/base.scss
+++ b/vendor/assets/stylesheets/watt/base.scss
@@ -39,7 +39,6 @@ $output-bourbon-deprecation-warnings: false;
 @import "watt/forms";
 @import "watt/footer";
 @import "watt/split";
-@import "watt/typekit";
 @import "watt/section_header";
 @import "watt/search_component";
 @import "watt/spinners";


### PR DESCRIPTION
We are using fonts.com now. While investigating an Ohm slow rendering issue, I realized we still have the typekit CSS styles here. Let's remove it! ✂️ 