### PR TITLE
AMBER-786: Remove old styles from watt

### DIFF
--- a/style-guide/source/elements/colors.html.haml
+++ b/style-guide/source/elements/colors.html.haml
@@ -21,6 +21,7 @@ title: Partner Engineering Style Guide
      '$green-light<br>#b0d766',
      '$green<br>#4f8200',
      '$white<br>#fff',
+     '$blue<br>#1023D7',
      '$black<br>#000'].each do |color_string|
     .col-md-6.color-sample
       %h4{ style: "background-color:" + color_string.split('<br>')[1] + ";" }= color_string

--- a/style-guide/source/stylesheets/style.css.scss
+++ b/style-guide/source/stylesheets/style.css.scss
@@ -11,7 +11,7 @@
   border: 1px solid $gray-lightest;
   margin-bottom: 3*$spacing-unit;
   > h4 {
-    @include avant-garde();
+    @include unica();
     border-bottom: 1px solid $gray-lightest;
     font-size: 14px;
     padding: 2*$spacing-unit;

--- a/vendor/assets/stylesheets/watt/_autocomplete.scss
+++ b/vendor/assets/stylesheets/watt/_autocomplete.scss
@@ -19,7 +19,7 @@ ul.ui-autocomplete {
       &:hover { text-decoration: none; }
     }
     a.ui-state-hover, a.ui-state-focus {
-      background-color: $purple;
+      background-color: $blue;
       color: $white;
     }
   }

--- a/vendor/assets/stylesheets/watt/_bootstrap_overrides.scss
+++ b/vendor/assets/stylesheets/watt/_bootstrap_overrides.scss
@@ -2,7 +2,7 @@ body {
   .navbar a,
   .nav-tabs a {
     text-transform: uppercase;
-    font-family: $sans-serif;
+    font-family: $sans-regular;
     -webkit-font-smoothing: antialiased;
   }
 }
@@ -47,7 +47,7 @@ body form {
     @extend .no-padding;
     font-size:13px;
     text-transform: uppercase;
-    font-family: $sans-serif;
+    font-family: $sans-regular;
   }
   label {
     font-weight: normal;

--- a/vendor/assets/stylesheets/watt/_bootstrap_variables.scss
+++ b/vendor/assets/stylesheets/watt/_bootstrap_variables.scss
@@ -46,7 +46,7 @@ $dropdown-link-active-bg: $navbar-default-link-active-bg;
 // Forms
 $input-color: $black;
 $input-border: $gray-lighter;
-$input-border-focus: $purple;
+$input-border-focus: $blue;
 $input-color-placeholder: $gray-light;
 
 $input-group-addon-bg: $white;

--- a/vendor/assets/stylesheets/watt/_bootstrap_variables.scss
+++ b/vendor/assets/stylesheets/watt/_bootstrap_variables.scss
@@ -2,7 +2,7 @@
 
 // Global
 $brand-primary: #000;
-$font-family-sans-serif: $sans-serif;
+$font-family-sans-serif: $sans-regular;
 $font-family-serif: $serif;
 $font-family-base: $serif;
 $font-size-base: 16px;

--- a/vendor/assets/stylesheets/watt/_breadcrumbs.scss
+++ b/vendor/assets/stylesheets/watt/_breadcrumbs.scss
@@ -31,7 +31,7 @@ $line-height: 18px;
       line-height: $line-height;
       text-decoration: none;
       &:hover {
-        color: $purple;
+        color: $blue;
         text-decoration: none;
       }
     }

--- a/vendor/assets/stylesheets/watt/_buttons.scss
+++ b/vendor/assets/stylesheets/watt/_buttons.scss
@@ -50,14 +50,14 @@ input[type="submit"].btn:visited,
   text-decoration: none;
 
   &:hover {
-    background-color: $purple;
+    background-color: $blue;
     color: $white;
     text-decoration: none;
   }
 
   &[data-state='loading'],
   &.is-loading {
-    background-color: $purple;
+    background-color: $blue;
     color: transparent;
     &:after {
       content: '';
@@ -104,14 +104,14 @@ a.btn.btn-primary,
   color: $white;
 
   &:hover {
-    background-color: $purple;
-    border-color: $purple;
+    background-color: $blue;
+    border-color: $blue;
     color: $white;
   }
 
   &[data-state='loading'],
   &.is-loading {
-    background-color: $purple;
+    background-color: $blue;
     color: transparent;
     &:after {
       content: '';
@@ -132,7 +132,7 @@ a.btn.btn-secondary,
   border-color: $gray;
   &:hover {
     background-color: $white;
-    color: $purple;
+    color: $blue;
   }
 
   &[data-state='loading'],
@@ -141,7 +141,7 @@ a.btn.btn-secondary,
     &:after {
       content: '';
       display: block;
-      @include spinner(25px, 6px, $purple);
+      @include spinner(25px, 6px, $blue);
     }
   }
 }
@@ -170,7 +170,7 @@ a.btn.btn-link,
     &:after {
       content: '';
       display: block;
-      @include spinner(25px, 6px, $purple);
+      @include spinner(25px, 6px, $blue);
     }
   }
 }
@@ -188,7 +188,7 @@ a.btn.btn-delete,
 
   &:hover {
     background-color: $white;
-    color: $purple;
+    color: $blue;
   }
 
   &[data-state='loading'],

--- a/vendor/assets/stylesheets/watt/_buttons.scss
+++ b/vendor/assets/stylesheets/watt/_buttons.scss
@@ -22,7 +22,7 @@ input[type="submit"].btn:visited,
   margin-bottom: 0;
   font: {
     weight: normal;
-    family: $sans-serif;
+    family: $sans-regular;
   }
   color: $black;
   text-align: center;

--- a/vendor/assets/stylesheets/watt/_checkboxes.scss
+++ b/vendor/assets/stylesheets/watt/_checkboxes.scss
@@ -44,7 +44,7 @@
       top: 3px;
     }
     &:hover {
-      border-color: $purple;
+      border-color: $blue;
       &::after {
         opacity: 0.1;
       }
@@ -56,7 +56,7 @@
     &:focus {
       outline: none;
       & + label {
-        border-color: $purple;
+        border-color: $blue;
         &:after {
           opacity: 0.1;
         }

--- a/vendor/assets/stylesheets/watt/_colors.scss
+++ b/vendor/assets/stylesheets/watt/_colors.scss
@@ -18,6 +18,7 @@ $green            : #0EDA83;
 $green-light      : #cff8e6;
 $white            : #fff;
 $black            : #000;
+$blue             : #1023D7;
 
 $notice-color     : $yellow-light;
 $base-border-color: $gray;

--- a/vendor/assets/stylesheets/watt/_contents.scss
+++ b/vendor/assets/stylesheets/watt/_contents.scss
@@ -5,7 +5,7 @@
 
 .artwork-artists {
   .artist-name {
-    @include avant-garde();
+    @include unica();
     font-size: 14px;
     line-height: 20px;
     text-transform: uppercase;

--- a/vendor/assets/stylesheets/watt/_contents.scss
+++ b/vendor/assets/stylesheets/watt/_contents.scss
@@ -49,7 +49,7 @@ main, section {
   .unit {
     strong {
       font-weight: normal;
-      font-family:$sans-serif;
+      font-family:$sans-regular;
       text-transform: uppercase;
       font-size:14px;
       line-height: 24px;
@@ -67,7 +67,7 @@ main, section {
       line-height: 12px;
       font: {
         weight: normal;
-        family: $sans-serif;
+        family: $sans-regular;
       }
       text-align: center;
       vertical-align: middle;
@@ -87,7 +87,7 @@ main, section {
     .previous-arrow,
     .next-arrow {
       font-size: 12px;
-      font-family:$sans-serif;
+      font-family:$sans-regular;
       text-transform: uppercase;
     }
     .next-arrow-icon {

--- a/vendor/assets/stylesheets/watt/_flash.scss
+++ b/vendor/assets/stylesheets/watt/_flash.scss
@@ -46,7 +46,7 @@
     }
   }
   .flash-wrap.flash-notice {
-    background-color: rgba($purple, 0.90);
+    background-color: rgba($blue, 0.90);
   }
   .flash-wrap.flash-error {
     background-color: rgba($red, 0.90);
@@ -79,7 +79,7 @@
     }
   }
   .flash-wrap.flash-notice {
-    background-color: rgba($purple, 0.90);
+    background-color: rgba($blue, 0.90);
   }
   .flash-wrap.flash-error {
     background-color: rgba($red, 0.90);

--- a/vendor/assets/stylesheets/watt/_flash.scss
+++ b/vendor/assets/stylesheets/watt/_flash.scss
@@ -88,7 +88,7 @@
 
 .flash-fullscreen {
   .flash-wrap {
-    @include avant-garde();
+    @include unica();
     background-color: rgba($black, 0.80);
     bottom: 0;
     font-size: 18px;

--- a/vendor/assets/stylesheets/watt/_fonts.scss
+++ b/vendor/assets/stylesheets/watt/_fonts.scss
@@ -10,7 +10,7 @@
 // Font Variables
 ////////////////////////////////////////////////////////////////////////////////
 $serif: "Adobe Garamond W08", Georgia, Serif;
-$sans-serif: "ITC Avant Garde Gothic W04", "Helvetica Neue", Arial, Helvetica, sans-serif;
+$sans-regular: "ITC Avant Garde Gothic W04", "Helvetica Neue", Arial, Helvetica, sans-serif;
 $sans-regular: Unica77LLWebRegular, "Helvetica Neue", Helvetica, Arial, sans-serif;
 $sans-medium: Unica77LLWebMedium, "Helvetica Neue", Helvetica, Arial, sans-serif;
 $sans-medium-italic: Unica77LLWebMediumItalic, "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -18,7 +18,7 @@ $sans-medium-italic: Unica77LLWebMediumItalic, "Helvetica Neue", Helvetica, Aria
 // Mixins with font smoothing
 ////////////////////////////////////////////////////////////////////////////////
 @mixin avant-garde() {
-  font-family: $sans-serif;
+  font-family: $sans-regular;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: normal;

--- a/vendor/assets/stylesheets/watt/_footer.scss
+++ b/vendor/assets/stylesheets/watt/_footer.scss
@@ -13,7 +13,7 @@ footer {
   height: 45px;
   line-height: 45px;
   display: block;
-  font-family: $sans-serif;
+  font-family: $sans-regular;
   text-transform: uppercase;
   font-size: 11px;
   span {

--- a/vendor/assets/stylesheets/watt/_grid.scss
+++ b/vendor/assets/stylesheets/watt/_grid.scss
@@ -57,7 +57,7 @@
       .grid-item-icon, a {
         color: $black;
         &:hover {
-          color: $purple;
+          color: $blue;
         }
       }
     }
@@ -174,14 +174,14 @@
   .artwork-grid-action-delete {
     &.active svg {
       circle {
-        fill: $purple;
+        fill: $blue;
       }
       path {
         fill: $white;
       }
       &:hover {
         circle {
-          fill: $purple;
+          fill: $blue;
         }
         path {
           fill: $white;

--- a/vendor/assets/stylesheets/watt/_grid.scss
+++ b/vendor/assets/stylesheets/watt/_grid.scss
@@ -30,7 +30,7 @@
 }
 
 .artwork-image-low-res {
-  @include avant-garde();
+  @include unica();
   background-color: $black;
   bottom: 0;
   color: $white;
@@ -95,7 +95,7 @@
     margin: 0 0 $spacing-unit 0;
   }
   .artwork-grid-item-artists {
-    @include avant-garde();
+    @include unica();
     @include ellipsis();
     display: block;
     font-size: 14px;
@@ -105,7 +105,7 @@
   .artwork-grid-item-display-data {
     font-size: 14px;
     span.data-label {
-      @include avant-garde();
+      @include unica();
       font-size: 11px;
     }
   }
@@ -115,7 +115,7 @@
     padding-top: $spacing-unit;
   }
   .artwork-grid-action {
-    @include avant-garde();
+    @include unica();
     color: $gray-darker;
     float: left;
     font-size: 12px;

--- a/vendor/assets/stylesheets/watt/_lists.scss
+++ b/vendor/assets/stylesheets/watt/_lists.scss
@@ -116,7 +116,7 @@
 }
 
 .list-group-item-artist-name {
-  @include avant-garde();
+  @include unica();
   font-size: 15px;
   line-height: 15px;
   word-break: normal;
@@ -330,7 +330,7 @@ a.list-pager-page-link {
     margin: 0;
     padding: 0;
     strong {
-      @include avant-garde();
+      @include unica();
       line-height: 100%;
     }
   }

--- a/vendor/assets/stylesheets/watt/_lists.scss
+++ b/vendor/assets/stylesheets/watt/_lists.scss
@@ -291,7 +291,7 @@ a.list-pager-page-link {
     margin-left: $spacing-unit/2;
   }
   .active {
-    color: $purple;
+    color: $blue;
     text-decoration: underline;
     &:hover {
       cursor: default;

--- a/vendor/assets/stylesheets/watt/_nav.scss
+++ b/vendor/assets/stylesheets/watt/_nav.scss
@@ -2,7 +2,7 @@ header.navigation {
   background-color: $black;
   clear: both;
   .nav, a {
-    @include avant-garde();
+    @include unica();
     color: $white;
     cursor: pointer;
     font-size: 12px;

--- a/vendor/assets/stylesheets/watt/_overview.scss
+++ b/vendor/assets/stylesheets/watt/_overview.scss
@@ -31,7 +31,7 @@
 
   .overview-item-title {
     @extend .col-md-4;
-    @include avant-garde();
+    @include unica();
     font-size: 14px;
   }
 

--- a/vendor/assets/stylesheets/watt/_panels.scss
+++ b/vendor/assets/stylesheets/watt/_panels.scss
@@ -3,7 +3,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 .panel {
   background-color: $gray-lightest;
-  border-left: 2px solid $purple;
+  border-left: 2px solid $blue;
   box-shadow: none;
   -webkit-box-shadow: none;
   -moz-box-shadow: none;
@@ -16,7 +16,7 @@
     a {
       text-decoration: underline;
       &:hover {
-        color: $purple;
+        color: $blue;
       }
       &.btn {
         text-decoration: none;
@@ -71,8 +71,8 @@
       border-bottom: 1px solid $black;
       text-decoration: none;
       &:hover {
-        color: $purple;
-        border-color: $purple;
+        color: $blue;
+        border-color: $blue;
       }
     }
   }

--- a/vendor/assets/stylesheets/watt/_panels.scss
+++ b/vendor/assets/stylesheets/watt/_panels.scss
@@ -65,7 +65,7 @@
   .panel-actions {
     text-align: center;
     a {
-      @include avant-garde();
+      @include unica();
       font-size: 12px;
       line-height: 1.5;
       border-bottom: 1px solid $black;

--- a/vendor/assets/stylesheets/watt/_progress_bar.scss
+++ b/vendor/assets/stylesheets/watt/_progress_bar.scss
@@ -34,8 +34,8 @@ $s: 768px;
   min-width: 120px;
   &.is-active {
     span {
-      border-color: $purple;
-      color: $purple;
+      border-color: $blue;
+      color: $blue;
     }
   }
   &:last-child { margin-right: 0; }

--- a/vendor/assets/stylesheets/watt/_progress_bar.scss
+++ b/vendor/assets/stylesheets/watt/_progress_bar.scss
@@ -23,7 +23,7 @@ $s: 768px;
   @include align-items(flex-end);
 }
 .progress-bar-item {
-  @include avant-garde();
+  @include unica();
   @include flex(1 1);
   display: inline-block;
   font-size: 9px;

--- a/vendor/assets/stylesheets/watt/_split_small.scss
+++ b/vendor/assets/stylesheets/watt/_split_small.scss
@@ -28,7 +28,7 @@ body.interface_layout {
       border-right: 1px solid $gray;
       ul {
         padding: 15px 0 30px 0;
-        font-family: $sans-serif;
+        font-family: $sans-regular;
         text-transform: uppercase;
         li {
           margin: 0;

--- a/vendor/assets/stylesheets/watt/_split_small.scss
+++ b/vendor/assets/stylesheets/watt/_split_small.scss
@@ -44,7 +44,7 @@ body.interface_layout {
         }
         li.active {
           a {
-            color: $purple;
+            color: $blue;
             background-color: $white;
           }
         }

--- a/vendor/assets/stylesheets/watt/_summary_detail.scss
+++ b/vendor/assets/stylesheets/watt/_summary_detail.scss
@@ -14,8 +14,8 @@
   padding-right: $spacing-unit;
   text-decoration: none;
   &:hover {
-    background-color: $purple;
-    border-top: 1px solid $purple;
+    background-color: $blue;
+    border-top: 1px solid $blue;
     color: $white;
   }
 }

--- a/vendor/assets/stylesheets/watt/_summary_detail.scss
+++ b/vendor/assets/stylesheets/watt/_summary_detail.scss
@@ -29,7 +29,7 @@
     border: none;
   }
   .summary-detail-label {
-    @include avant-garde();
+    @include unica();
     font-size: 12px;
   }
   .summary-detail-action {

--- a/vendor/assets/stylesheets/watt/_tabs.scss
+++ b/vendor/assets/stylesheets/watt/_tabs.scss
@@ -87,8 +87,8 @@ $s: 768px;
     display: block;
     padding: 16px;
     &:focus, &:hover {
-      border-color: $purple;
-      color: $purple;
+      border-color: $blue;
+      color: $blue;
       outline: none;
       text-decoration: none;
       @include transition(color 0.25s ease-in-out, border-color 0.25s ease-in-out);

--- a/vendor/assets/stylesheets/watt/_tabs.scss
+++ b/vendor/assets/stylesheets/watt/_tabs.scss
@@ -67,7 +67,7 @@ $s: 768px;
   }
 }
 .tab-item {
-  @include avant-garde();
+  @include unica();
   display: inline-block;
   font-size: 10px;
   list-style: none;

--- a/vendor/assets/stylesheets/watt/_toggles.scss
+++ b/vendor/assets/stylesheets/watt/_toggles.scss
@@ -8,7 +8,7 @@
 }
 
 .toggle {
-  @include avant-garde();
+  @include unica();
   background-color: white;
   border: 2px solid $gray-lighter;
   border-radius: 15px;

--- a/vendor/assets/stylesheets/watt/_toggles.scss
+++ b/vendor/assets/stylesheets/watt/_toggles.scss
@@ -2,7 +2,7 @@
   display: inline-block;
   margin-left: 10px;
   &:hover {
-    color: $purple;
+    color: $blue;
     cursor: pointer;
   }
 }
@@ -21,7 +21,7 @@
   width: 58px;
   &:focus, &:hover {
     @extend .toggle-label;
-    color: $purple;
+    color: $blue;
     text-decoration: none;
     margin: 0;
     padding: 0;
@@ -51,8 +51,8 @@
   }
   &[data-state='on'],
   &[data-state='yes'] {
-    background-color: $purple;
-    border-color: $purple;
+    background-color: $blue;
+    border-color: $blue;
     .toggle-dot {
       color: white;
       left: 33px;


### PR DESCRIPTION
# [AMBER-786](https://artsyproduct.atlassian.net/browse/AMBER-786) Remove old styles from watt

__Description__
This ticket is to remove the old artsy purple brand color and avant garde fonts from watt so that the components used by other apps (like volt) are less jarring when viewed with the new design system and brand style.

There isn't really any good way to test this before merging, but its only visual changes that can be reverted if necessary.

[AMBER-786]: https://artsyproduct.atlassian.net/browse/AMBER-786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ