### PR TITLE
AMBER-786: Remove old styles from watt

### DIFF
--- a/vendor/assets/stylesheets/watt/_fonts.scss
+++ b/vendor/assets/stylesheets/watt/_fonts.scss
@@ -10,7 +10,7 @@
 // Font Variables
 ////////////////////////////////////////////////////////////////////////////////
 $serif: "Adobe Garamond W08", Georgia, Serif;
-$sans-regular: "ITC Avant Garde Gothic W04", "Helvetica Neue", Arial, Helvetica, sans-serif;
+$sans-serif: "ITC Avant Garde Gothic W04", "Helvetica Neue", Arial, Helvetica, sans-serif;
 $sans-regular: Unica77LLWebRegular, "Helvetica Neue", Helvetica, Arial, sans-serif;
 $sans-medium: Unica77LLWebMedium, "Helvetica Neue", Helvetica, Arial, sans-serif;
 $sans-medium-italic: Unica77LLWebMediumItalic, "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -27,6 +27,12 @@ $sans-medium-italic: Unica77LLWebMediumItalic, "Helvetica Neue", Helvetica, Aria
 
 @mixin garamond() {
   font-family: $serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+@mixin unica() {
+  font-family: $sans-regular;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
# [AMBER-786](https://artsyproduct.atlassian.net/browse/AMBER-786) Remove old styles from watt

__Description__
This ticket is to remove the old artsy purple brand color and avant garde fonts from watt so that the components used by other apps (like volt) are less jarring when viewed with the new design system and brand style.

There isn't really any good way to test this before merging, but its only visual changes that can be reverted if necessary.

[AMBER-786]: https://artsyproduct.atlassian.net/browse/AMBER-786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ