### PR TITLE
feat(panel): add borderless class

### DIFF
--- a/vendor/assets/stylesheets/watt/_panels.scss
+++ b/vendor/assets/stylesheets/watt/_panels.scss
@@ -40,6 +40,9 @@
       max-width: 440px;
     }
   }
+  &.borderless {
+    border: none;
+  }
   .width-constrained {
     max-width: 660px;
   }


### PR DESCRIPTION
Adds a borderless class to show the panel without the blue border; it comes from Design feedback.

PS: looks like the pipeline has always been broken

cc @artsy/topaz-devs 